### PR TITLE
Fix formatting of diff lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.0.5 (2018-11-20)
+------------------
+
+* `#15 <https://github.com/ESSS/pytest-regressions/pull/15>`__: Remove some extra line separators from the diff output, which makes the representation more compact.
+
 1.0.4 (2018-10-18)
 ------------------
 

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -35,7 +35,9 @@ def check_text_files(obtained_fn, expected_fn, fix_callback=lambda x: x, encodin
     expected_lines = expected_fn.read_text(encoding=encoding).splitlines()
 
     if obtained_lines != expected_lines:
-        diff_lines = list(difflib.unified_diff(expected_lines, obtained_lines, lineterm=''))
+        diff_lines = list(
+            difflib.unified_diff(expected_lines, obtained_lines, lineterm="")
+        )
         if len(diff_lines) <= 500:
             html_fn = obtained_fn.with_suffix(".diff.html")
             try:

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -35,7 +35,7 @@ def check_text_files(obtained_fn, expected_fn, fix_callback=lambda x: x, encodin
     expected_lines = expected_fn.read_text(encoding=encoding).splitlines()
 
     if obtained_lines != expected_lines:
-        diff_lines = list(difflib.unified_diff(expected_lines, obtained_lines))
+        diff_lines = list(difflib.unified_diff(expected_lines, obtained_lines, lineterm=''))
         if len(diff_lines) <= 500:
             html_fn = obtained_fn.with_suffix(".diff.html")
             try:


### PR DESCRIPTION
This patch leaves `\n` off the end of the diff's header lines, since the newline is added again by other code.  It fixes a small formatting glitch in failing tests:

Before:
![before-line-end-fix](https://user-images.githubusercontent.com/229502/48732941-1cfff080-ec0f-11e8-9c38-b2138a311699.png)

After:
![after-line-end-fix](https://user-images.githubusercontent.com/229502/48732940-1cfff080-ec0f-11e8-84dc-7b9a5dc66c36.png)

