### PR TITLE
Fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ environment:
       TOXENV: "py37"
 
 install:
-  - "%PYTHON%\\python -m pip install -U pip"
   - "%PYTHON%\\python -m pip install -U setuptools tox"
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = py27,py35,py36,py37,docs,linting
 
 [testenv]
+download = true
 extras = dev
 commands = pytest {posargs:tests}
 


### PR DESCRIPTION
Allows tox to use a new downloaded version of `pip`, otherwise it uses a
bundled version that is too old