### PR TITLE
num_regression: use logical XOR to check boolean arrays, instead of subtraction.

### DIFF
--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -133,7 +133,10 @@ class NumericRegressionFixture(object):
                 diff_ids = np.where(not_close_mask)[0]
                 diff_obtained_data = obtained_column[diff_ids]
                 diff_expected_data = expected_column[diff_ids]
-                diffs = np.abs(obtained_column - expected_column)[diff_ids]
+                if data_type == np.bool:
+                    diffs = np.logical_xor(obtained_column, expected_column)[diff_ids]
+                else:
+                    diffs = np.abs(obtained_column - expected_column)[diff_ids]
 
                 comparison_table = pd.concat(
                     [diff_obtained_data, diff_expected_data, diffs], axis=1

--- a/tests/test_num_regression.py
+++ b/tests/test_num_regression.py
@@ -225,3 +225,27 @@ def test_fill_different_shape_with_nan_for_non_float_array(num_regression, no_re
         match="Checking multiple arrays with different shapes are not supported for non-float arrays",
     ):
         num_regression.check({"data1": data1, "data2": data2, "data3": data3})
+
+
+def test_bool_array(num_regression, no_regen):
+    data1 = np.array([True, True, True], dtype=np.bool)
+    with pytest.raises(AssertionError) as excinfo:
+        num_regression.check({"data1": data1})
+    obtained_error_msg = str(excinfo.value)
+    expected = "\n".join(
+        [
+            "Values are not sufficiently close.",
+            "To update values, use --force-regen option.",
+        ]
+    )
+    assert expected in obtained_error_msg
+    expected = "\n".join(
+        [
+            "data1:",
+            "   obtained_data1  expected_data1  diff",
+            "0            True           False  True",
+            "1            True           False  True",
+            "2            True           False  True",
+        ]
+    )
+    assert expected in obtained_error_msg

--- a/tests/test_num_regression/test_bool_array.csv
+++ b/tests/test_num_regression/test_bool_array.csv
@@ -1,0 +1,4 @@
+,data1
+0,False
+1,False
+2,False


### PR DESCRIPTION
This should fix #22 .

I could not run `tox` under a Python 3.7 environment, but all the other tests are passing.