### PR TITLE
Fix the bug with the shapes.

### DIFF
--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -257,6 +257,7 @@ class NumericRegressionFixture:
             )
             data_shapes.append(shape[0])
 
+        data_shapes = np.array(data_shapes)
         if not np.all(data_shapes == data_shapes[0]):
             if not fill_different_shape_with_nan:
                 assert (

--- a/tests/test_num_regression.py
+++ b/tests/test_num_regression.py
@@ -249,3 +249,11 @@ def test_bool_array(num_regression, no_regen):
         ]
     )
     assert expected in obtained_error_msg
+
+
+def test_arrays_of_same_size(num_regression):
+    same_size_int_arrays = {
+        "hello": np.zeros((1,), dtype=np.int),
+        "world": np.zeros((1,), dtype=np.int),
+    }
+    num_regression.check(same_size_int_arrays)

--- a/tests/test_num_regression/test_arrays_of_same_size.csv
+++ b/tests/test_num_regression/test_arrays_of_same_size.csv
@@ -1,0 +1,2 @@
+,hello,world
+0,0,0


### PR DESCRIPTION
`data_shapes == data_shapes[0]` is always `False` because `data_shapes` is a list, not a numpy array.

We're going to use pytest-regression in tensorflow-addons, this library is exactly what we needed :)