### PR TITLE
Don't create file before yaml serializing, avoid create empty file if fails for some reason

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+2.0.2 (2020-10-07)
+------------------
+
+* `#34 <https://github.com/ESSS/pytest-regressions/pull/34>`__: Fix ``data_regression`` bug that creates empty file on serializing error.
+
 2.0.1 (2020-05-18)
 ------------------
 

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -43,16 +43,16 @@ class DataRegressionFixture:
             """Dump dict contents to the given filename"""
             import yaml
 
+            dumped_str = yaml.dump_all(
+                [data_dict],
+                Dumper=RegressionYamlDumper,
+                default_flow_style=False,
+                allow_unicode=True,
+                indent=2,
+                encoding="utf-8",
+            )
             with filename.open("wb") as f:
-                yaml.dump_all(
-                    [data_dict],
-                    f,
-                    Dumper=RegressionYamlDumper,
-                    default_flow_style=False,
-                    allow_unicode=True,
-                    indent=2,
-                    encoding="utf-8",
-                )
+                f.write(dumped_str)
 
         perform_regression_check(
             datadir=self.datadir,

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -169,3 +169,25 @@ def test_data_regression_no_aliases(testdir):
     )
     result = testdir.inline_run()
     result.assertoutcome(passed=1)
+
+
+def test_not_create_file_on_error(testdir):
+    """Basic example where we serializing the object should throw an error and should not create the file"""
+
+    source = """
+        def test(data_regression):
+            class Scalar:
+                def __init__(self, value, unit):
+                    self.value = value
+                    self.unit = unit
+
+            contents = {"scalar": Scalar(10, "m")}
+            data_regression.Check(contents)
+    """
+    testdir.makepyfile(test_file=source)
+
+    result = testdir.inline_run()
+    result.assertoutcome(failed=1)
+
+    yaml_file = testdir.tmpdir.join("test_file", "test.yml")
+    assert not yaml_file.isfile()


### PR DESCRIPTION
Fix #33 