### PR TITLE
Replace deprecated numpy type aliases with builtin equivalents

### DIFF
--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -123,7 +123,7 @@ class DataFrameRegressionFixture:
             self._check_data_shapes(obtained_column, expected_column)
 
             data_type = obtained_column.values.dtype
-            if data_type in [float, np.float, np.float16, np.float32, np.float64]:
+            if data_type in [float, np.float16, np.float32, np.float64]:
                 not_close_mask = ~np.isclose(
                     obtained_column.values,
                     expected_column.values,
@@ -137,7 +137,7 @@ class DataFrameRegressionFixture:
                 diff_ids = np.where(not_close_mask)[0]
                 diff_obtained_data = obtained_column[diff_ids]
                 diff_expected_data = expected_column[diff_ids]
-                if data_type == np.bool:
+                if data_type == bool:
                     diffs = np.logical_xor(obtained_column, expected_column)[diff_ids]
                 else:
                     diffs = np.abs(obtained_column - expected_column)[diff_ids]

--- a/tests/test_dataframe_regression.py
+++ b/tests/test_dataframe_regression.py
@@ -193,7 +193,7 @@ def test_arrays_with_different_sizes(dataframe_regression, no_regen):
 
 
 def test_integer_values_smoke_test(dataframe_regression, no_regen):
-    data1 = np.ones(11, dtype=np.int)
+    data1 = np.ones(11, dtype=int)
     dataframe_regression.check(pd.DataFrame.from_dict({"data1": data1}))
 
 
@@ -203,7 +203,7 @@ def test_number_formats(dataframe_regression, no_regen):
 
 
 def test_bool_array(dataframe_regression, no_regen):
-    data1 = np.array([True, True, True], dtype=np.bool)
+    data1 = np.array([True, True, True], dtype=bool)
     with pytest.raises(AssertionError) as excinfo:
         dataframe_regression.check(pd.DataFrame.from_dict({"data1": data1}))
     obtained_error_msg = str(excinfo.value)
@@ -228,8 +228,8 @@ def test_bool_array(dataframe_regression, no_regen):
 
 def test_arrays_of_same_size(dataframe_regression):
     same_size_int_arrays = {
-        "hello": np.zeros((1,), dtype=np.int),
-        "world": np.zeros((1,), dtype=np.int),
+        "hello": np.zeros((1,), dtype=int),
+        "world": np.zeros((1,), dtype=int),
     }
     dataframe_regression.check(pd.DataFrame.from_dict(same_size_int_arrays))
 

--- a/tests/test_num_regression.py
+++ b/tests/test_num_regression.py
@@ -169,7 +169,7 @@ def test_different_data_types(num_regression, no_regen):
 
 
 def test_n_dimensions(num_regression, no_regen):
-    data1 = np.ones(shape=(10, 10), dtype=np.int)
+    data1 = np.ones(shape=(10, 10), dtype=int)
     with pytest.raises(
         AssertionError,
         match="Only 1D arrays are supported on num_data_regression fixture.",
@@ -186,7 +186,7 @@ def test_arrays_with_different_sizes(num_regression, no_regen):
 
 
 def test_integer_values_smoke_test(num_regression, no_regen):
-    data1 = np.ones(11, dtype=np.int)
+    data1 = np.ones(11, dtype=int)
     num_regression.check({"data1": data1})
 
 
@@ -228,7 +228,7 @@ def test_fill_different_shape_with_nan_for_non_float_array(num_regression, no_re
 
 
 def test_bool_array(num_regression, no_regen):
-    data1 = np.array([True, True, True], dtype=np.bool)
+    data1 = np.array([True, True, True], dtype=bool)
     with pytest.raises(AssertionError) as excinfo:
         num_regression.check({"data1": data1})
     obtained_error_msg = str(excinfo.value)
@@ -253,8 +253,8 @@ def test_bool_array(num_regression, no_regen):
 
 def test_arrays_of_same_size(num_regression):
     same_size_int_arrays = {
-        "hello": np.zeros((1,), dtype=np.int),
-        "world": np.zeros((1,), dtype=np.int),
+        "hello": np.zeros((1,), dtype=int),
+        "world": np.zeros((1,), dtype=int),
     }
     num_regression.check(same_size_int_arrays)
 


### PR DESCRIPTION
Numpy 1.20 deprecated several type aliases to builtin types (ref. https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

Replace `np.float`, `np.int` and `np.bool` with their builtin equivalents.

Fixes #48.