### PR TITLE
Docstring clarification for dataframe_regression

### DIFF
--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -177,7 +177,7 @@ class DataFrameRegressionFixture:
         default_tolerance=None,
     ):
         """
-        Checks the given pandas dataframe against a previously recorded version, or generate a new file.
+        Checks a pandas dataframe, containing only numeric data, against a previously recorded version, or generate a new file.
 
         Example::
 


### PR DESCRIPTION
Make it more clear that dataframe_regression only accepts dataframes with numeric data.