### PR TITLE
Add reorder-python-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,11 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py36-plus]
 -   repo: local
     hooks:
     -   id: rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,9 +5,7 @@
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -15,8 +13,6 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
-
 # -- Project information -----------------------------------------------------
 
 project = "pytest-regressions"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-
-import os
 import codecs
-from setuptools import setup, find_packages
+import os
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(fname):

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -1,8 +1,7 @@
 import difflib
-import pytest
-
-
 from pathlib import Path
+
+import pytest
 
 
 def import_error_message(libname):

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -2,7 +2,9 @@ from functools import partial
 
 import yaml
 
-from pytest_regressions.common import Path, check_text_files, perform_regression_check
+from pytest_regressions.common import check_text_files
+from pytest_regressions.common import Path
+from pytest_regressions.common import perform_regression_check
 
 
 class DataRegressionFixture:

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -1,4 +1,5 @@
-from pytest_regressions.common import perform_regression_check, import_error_message
+from pytest_regressions.common import import_error_message
+from pytest_regressions.common import perform_regression_check
 
 
 class DataFrameRegressionFixture:

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -1,6 +1,7 @@
 from functools import partial
 
-from .common import perform_regression_check, check_text_files
+from .common import check_text_files
+from .common import perform_regression_check
 
 
 class FileRegressionFixture:

--- a/src/pytest_regressions/image_regression.py
+++ b/src/pytest_regressions/image_regression.py
@@ -1,7 +1,8 @@
 import io
 from functools import partial
 
-from pytest_regressions.common import perform_regression_check, import_error_message
+from pytest_regressions.common import import_error_message
+from pytest_regressions.common import perform_regression_check
 
 
 class ImageRegressionFixture:

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -1,4 +1,5 @@
-from pytest_regressions.common import perform_regression_check, import_error_message
+from pytest_regressions.common import import_error_message
+from pytest_regressions.common import perform_regression_check
 
 
 class NDArraysRegressionFixture:

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -1,4 +1,5 @@
-from pytest_regressions.common import perform_regression_check, import_error_message
+from pytest_regressions.common import import_error_message
+from pytest_regressions.common import perform_regression_check
 from pytest_regressions.dataframe_regression import DataFrameRegressionFixture
 
 

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from textwrap import dedent
 
 from pytest_regressions.testing import check_regression_fixture_workflow

--- a/tests/test_file_regression.py
+++ b/tests/test_file_regression.py
@@ -1,9 +1,8 @@
-from __future__ import unicode_literals
 import textwrap
-from pytest_regressions.common import Path
 
 import pytest
 
+from pytest_regressions.common import Path
 from pytest_regressions.testing import check_regression_fixture_workflow
 
 

--- a/tests/test_filenames.py
+++ b/tests/test_filenames.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 def test_foo(datadir, num_regression):

--- a/tests/test_image_regression.py
+++ b/tests/test_image_regression.py
@@ -1,7 +1,7 @@
 import io
 from functools import partial
-from pytest_regressions.common import Path
 
+from pytest_regressions.common import Path
 from pytest_regressions.testing import check_regression_fixture_workflow
 
 


### PR DESCRIPTION
This keeps imports organized automatically in a way to avoid conflicts. See [the docs](https://github.com/asottile/reorder_python_imports#why-this-style) for the rationale.