### PR TITLE
Add NDArraysRegressionFixture to api docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
         include:
           - python: "3.6"
@@ -21,6 +21,11 @@ jobs:
             tox_env: "py38"
           - python: "3.9"
             tox_env: "py39"
+          - python: "3.10"
+            tox_env: "py310"
+        exclude:
+          - python: "3.6"
+            os: windows-latest
 
     steps:
     - uses: actions/checkout@v1

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = pytest-regressions
 SOURCEDIR     = .

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -30,3 +30,9 @@ image_regression
 ----------------
 
 .. automethod:: pytest_regressions.image_regression.ImageRegressionFixture.check
+
+
+ndarrays_regression
+-------------------
+
+.. automethod:: pytest_regressions.ndarrays_regression.NDArraysRegressionFixture.check

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,docs,linting
+envlist = py36,py37,py38,py39,py310,docs,linting
 
 [testenv]
 download = true


### PR DESCRIPTION
I've also added treating sphinx warnings as errors.
This would make sure that a typo fails the build
and not silently drop anythin from autodoc.
