### PR TITLE
Update dataframe_regression.py

### DIFF
--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -124,7 +124,7 @@ class DataFrameRegressionFixture:
             self._check_data_types(k, obtained_column, expected_column)
             self._check_data_shapes(obtained_column, expected_column)
 
-            if np.issubdtype(obtained_column.values.dtype, np.inexact):
+            if np.issubdtype(obtained_column.values.dtype, np.number):
                 not_close_mask = ~np.isclose(
                     obtained_column.values,
                     expected_column.values,


### PR DESCRIPTION
Currently the check performed on numeric values checks if the obtained column dtype is of subtype np.inexact.
This excludes tolerances for Integer values. Proposed change allows Integers as well