### PR TITLE
Add --regen-all flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.4.0 (2022-09-09)
+------------------
+
+* New ``--regen-all`` flag, which regenerates all files without failing the tests. Useful to regenerate all files in
+  the test suite with a single run.
+
 2.3.1 (2022-01-18)
 ------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -122,15 +122,29 @@ This file should be committed to version control.
 The next time you run this test, it will compare the results of ``summary_grids()`` with the contents of the YAML file.
 If they match, the test passes. If they don't match the test will fail, showing a nice diff of the text differences.
 
+``--force-regen``
+~~~~~~~~~~~~~~~~~
+
 If the test fails because the new data is correct (the implementation might be returning more information about the
 grids for example), then you can use the ``--force-regen`` flag to update the expected file::
 
     $ pytest --force-regen
 
 
-and commit the updated file.
+This will fail the same test but with a different message saying that the file has been updated. Commit the new file.
 
 This workflow makes it very simple to keep the files up to date and to check all the information we need.
+
+``--regen-all``
+~~~~~~~~~~~~~~~~~
+
+If a single change will fail several regression tests, you can also use the ``--regen-all`` command-line flag::
+
+    $ pytest --regen-all
+
+
+With this flag, the regression fixtures will regenerate all files but will not fail the tests themselves. This make it very
+easy to update all regression files in a single pytest run when individual tests contain multiple regressions.
 
 
 Parametrized tests

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ def read(fname):
 setup(
     name="pytest-regressions",
     use_scm_version=True,
-    setup_requires=["setuptools_scm"],
+    setup_requires=[
+        "setuptools_scm; python_version>'3.6'",
+        "setuptools_scm <7.0; python_version=='3.6'",
+    ],
     author="ESSS",
     author_email="foss@esss.co",
     maintainer="Bruno Oliveira",

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -138,7 +138,12 @@ def perform_regression_check(
         return "\n".join(msg)
 
     force_regen = force_regen or request.config.getoption("force_regen")
-    if not filename.is_file():
+    regen_all = request.config.getoption("regen_all")
+    if regen_all:
+        source_filename.parent.mkdir(parents=True, exist_ok=True)
+        dump_fn(source_filename)
+        dump_aux_fn(source_filename)
+    elif not filename.is_file():
         source_filename.parent.mkdir(parents=True, exist_ok=True)
         dump_fn(source_filename)
         aux_created = dump_aux_fn(source_filename)

--- a/src/pytest_regressions/plugin.py
+++ b/src/pytest_regressions/plugin.py
@@ -7,7 +7,13 @@ def pytest_addoption(parser):
         "--force-regen",
         action="store_true",
         default=False,
-        help="Re-generate all data_regression fixture data files.",
+        help="Regenerate regression data files, failing tests with different data.",
+    )
+    group.addoption(
+        "--regen-all",
+        action="store_true",
+        default=False,
+        help="Regenerate all files, letting tests pass (use to regenerate everything in one run).",
     )
     group.addoption(
         "--with-test-class-names",


### PR DESCRIPTION
This flag differs from `--force-regen` in that it always regenerates the files, and more importantly, does not fail the tests.

This simplifies a lot updating many tests that contain multiple regression files.