### PR TITLE
Use mypy for typing check and fully annotate public API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,31 +41,13 @@ jobs:
       run: |
         tox -e ${{ matrix.tox_env }}
 
-  linting:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: "3.7"
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Linting
-      run: |
-        tox -e linting
-
   deploy:
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     runs-on: ubuntu-latest
 
-    needs: [build, linting]
+    needs: build
 
     steps:
     - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,29 @@
 exclude: '^($|.*\.bin)'
 repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+-   repo: https://github.com/myint/autoflake
+    rev: v1.5.3
+    hooks:
+    -   id: autoflake
+        name: autoflake
+        args: ["--in-place", "--remove-unused-variables", "--remove-all-unused-imports"]
+        language: python
+        files: \.py$
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.8.2
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py36-plus]
 -   repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
     -   id: black
         args: [--safe, --quiet]
         language_version: python3.7
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.8.2
-    hooks:
-    -   id: reorder-python-imports
-        args: ['--application-directories=.:src', --py36-plus]
 -   repo: local
     hooks:
     -   id: rst

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@
 
 * New ``--regen-all`` flag, which regenerates all files without failing the tests. Useful to regenerate all files in
   the test suite with a single run.
+* The public API is now fully type annotated.
+* ``pytest>=6.2`` is now required.
 
 2.3.1 (2022-01-18)
 ------------------

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,3 +14,7 @@ no_implicit_reexport = True
 local_partial_types = True
 ; workaround for https://github.com/python/mypy/issues/10709
 ignore_missing_imports_per_module = True
+
+
+[mypy-pytest_regressions]
+disallow_untyped_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+files = src,tests
+check_untyped_defs = True
+disallow_any_generics = True
+ignore_missing_imports = True
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+no_implicit_reexport = True
+local_partial_types = True
+; workaround for https://github.com/python/mypy/issues/10709
+ignore_missing_imports_per_module = True

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python
-import codecs
-import os
+from pathlib import Path
 
 from setuptools import find_packages
 from setuptools import setup
 
 
-def read(fname):
-    file_path = os.path.join(os.path.dirname(__file__), fname)
-    return codecs.open(file_path, encoding="utf-8").read()
+def read(fname: str) -> str:
+    file_path = Path(__file__).parent / fname
+    return file_path.read_text(encoding="UTF-8")
 
 
 setup(
@@ -32,6 +30,7 @@ setup(
     extras_require={
         "dev": [
             "matplotlib",
+            "mypy",
             "numpy",
             "pandas",
             "pillow",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     python_requires=">=3.6",
+    package_data={
+        "pytest_regressions": ["py.typed"],
+    },
     extras_require={
         "dev": [
             "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "image": ["pillow", "numpy"],
         "dataframe": ["numpy", "pandas"],
     },
-    install_requires=["pytest-datadir>=1.2.0", "pytest>=3.5.0", "pyyaml"],
+    install_requires=["pytest-datadir>=1.2.0", "pytest>=6.2.0", "pyyaml"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Pytest",

--- a/src/pytest_regressions/__init__.py
+++ b/src/pytest_regressions/__init__.py
@@ -1,4 +1,7 @@
-def add_custom_yaml_representer(data_type, representer_fn):
+from typing import Any
+
+
+def add_custom_yaml_representer(data_type: type, representer_fn: Any) -> None:
     """
     Add custom representer to regression YAML dumper. It is polymorphic, so it works also for
     subclasses of `data_type`.

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -87,10 +87,10 @@ def perform_regression_check(
     dump_fn: Callable[[Path], None],
     extension: str,
     basename: Optional[str] = None,
-    fullpath: Optional[Path] = None,
+    fullpath: Optional[Union[Path, str]] = None,
     force_regen: bool = False,
     with_test_class_names: bool = False,
-    obtained_filename: Optional[Path] = None,
+    obtained_filename: Optional[Union[Path, str]] = None,
     dump_aux_fn: Callable[[Path], List[str]] = lambda filename: [],
 ) -> None:
     """
@@ -172,10 +172,10 @@ def perform_regression_check(
             else:
                 obtained_filename = filename.with_suffix(".obtained" + extension)
 
-        dump_fn(obtained_filename)
+        dump_fn(Path(obtained_filename))
 
         try:
-            check_fn(obtained_filename, filename)
+            check_fn(Path(obtained_filename), Path(filename))
         except AssertionError:
             if force_regen:
                 dump_fn(source_filename)
@@ -187,5 +187,5 @@ def perform_regression_check(
                 )
                 pytest.fail(msg)
             else:
-                dump_aux_fn(obtained_filename)
+                dump_aux_fn(Path(obtained_filename))
                 raise

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import difflib
 import os
 from pathlib import Path

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -1,10 +1,10 @@
 # mypy: disallow-untyped-defs
 import difflib
+import os
 from pathlib import Path
 from typing import Callable
 from typing import List
 from typing import Optional
-from typing import Union
 
 import pytest
 
@@ -14,8 +14,8 @@ def import_error_message(libname: str) -> str:
 
 
 def check_text_files(
-    obtained_fn: Union[Path, str],
-    expected_fn: Union[Path, str],
+    obtained_fn: "os.PathLike[str]",
+    expected_fn: "os.PathLike[str]",
     fix_callback: Callable[[List[str]], List[str]] = lambda x: x,
     encoding: Optional[str] = None,
 ) -> None:
@@ -87,10 +87,10 @@ def perform_regression_check(
     dump_fn: Callable[[Path], None],
     extension: str,
     basename: Optional[str] = None,
-    fullpath: Optional[Union[Path, str]] = None,
+    fullpath: Optional["os.PathLike[str]"] = None,
     force_regen: bool = False,
     with_test_class_names: bool = False,
-    obtained_filename: Optional[Union[Path, str]] = None,
+    obtained_filename: Optional["os.PathLike[str]"] = None,
     dump_aux_fn: Callable[[Path], List[str]] = lambda filename: [],
 ) -> None:
     """

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -3,7 +3,6 @@ from functools import partial
 import yaml
 
 from pytest_regressions.common import check_text_files
-from pytest_regressions.common import Path
 from pytest_regressions.common import perform_regression_check
 
 

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import pytest
 import yaml
@@ -31,7 +32,7 @@ class DataRegressionFixture:
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Path] = None,
+        fullpath: Optional[Union[Path, str]] = None,
     ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import os
 from functools import partial
 from pathlib import Path

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -1,9 +1,16 @@
+# mypy: disallow-untyped-defs
 from functools import partial
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
 
+import pytest
 import yaml
 
-from pytest_regressions.common import check_text_files
-from pytest_regressions.common import perform_regression_check
+from .common import check_text_files
+from .common import perform_regression_check
 
 
 class DataRegressionFixture:
@@ -11,29 +18,31 @@ class DataRegressionFixture:
     Implementation of `data_regression` fixture.
     """
 
-    def __init__(self, datadir, original_datadir, request):
-        """
-        :type datadir: Path
-        :type original_datadir: Path
-        :type request: FixtureRequest
-        """
+    def __init__(
+        self, datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+    ) -> None:
         self.request = request
         self.datadir = datadir
         self.original_datadir = original_datadir
         self.force_regen = False
         self.with_test_class_names = False
 
-    def check(self, data_dict, basename=None, fullpath=None):
+    def check(
+        self,
+        data_dict: Dict[str, Any],
+        basename: Optional[str] = None,
+        fullpath: Optional[Path] = None,
+    ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.
 
-        :param dict data_dict: any yaml serializable dict.
+        :param data_dict: any yaml serializable dict.
 
-        :param str basename: basename of the file to test/record. If not given the name
+        :param basename: basename of the file to test/record. If not given the name
             of the test is used.
             Use either `basename` or `fullpath`.
 
-        :param str fullpath: complete path to use as a reference file. This option
+        :param fullpath: complete path to use as a reference file. This option
             will ignore ``datadir`` fixture when reading *expected* files but will still use it to
             write *obtained* files. Useful if a reference file is located in the session data dir for example.
 
@@ -41,7 +50,7 @@ class DataRegressionFixture:
         """
         __tracebackhide__ = True
 
-        def dump(filename):
+        def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""
             import yaml
 
@@ -83,17 +92,19 @@ class RegressionYamlDumper(yaml.SafeDumper):
     (see http://pyyaml.org/ticket/91).
     """
 
-    def ignore_aliases(self, data):
+    def ignore_aliases(self, data: object) -> bool:
         return True
 
     @classmethod
-    def add_custom_yaml_representer(cls, data_type, representer_fn):
+    def add_custom_yaml_representer(
+        cls, data_type: type, representer_fn: Callable[[object, Any], None]
+    ) -> None:
         """
         Add custom representer to regression YAML dumper. It is polymorphic, so it works also for
         subclasses of `data_type`.
 
-        :param type data_type: Type of objects.
-        :param callable representer_fn: Function that receives ``(dumper, data)`` type as
+        :param data_type: Type of objects.
+        :param representer_fn: Function that receives ``(dumper, data)`` type as
             argument and must must return a YAML-convertible representation.
         """
         # Use multi-representer instead of simple-representer because it supports polymorphism.

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -1,11 +1,11 @@
 # mypy: disallow-untyped-defs
+import os
 from functools import partial
 from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
-from typing import Union
 
 import pytest
 import yaml
@@ -32,7 +32,7 @@ class DataRegressionFixture:
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Union[Path, str]] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
     ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -1,5 +1,13 @@
-from pytest_regressions.common import import_error_message
-from pytest_regressions.common import perform_regression_check
+# mypy: disallow-untyped-defs
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+import pytest
+
+from .common import import_error_message
+from .common import perform_regression_check
 
 
 class DataFrameRegressionFixture:
@@ -11,14 +19,11 @@ class DataFrameRegressionFixture:
     DISPLAY_WIDTH = 1000  # Max. Chars on outputs
     DISPLAY_MAX_COLUMNS = 1000  # Max. Number of columns (see #3)
 
-    def __init__(self, datadir, original_datadir, request):
-        """
-        :type datadir: Path
-        :type original_datadir: Path
-        :type request: FixtureRequest
-        """
-        self._tolerances_dict = {}
-        self._default_tolerance = {}
+    def __init__(
+        self, datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+    ) -> None:
+        self._tolerances_dict: Dict[str, Dict[str, float]] = {}
+        self._default_tolerance: Dict[str, float] = {}
 
         self.request = request
         self.datadir = datadir
@@ -35,7 +40,9 @@ class DataFrameRegressionFixture:
             DataFrameRegressionFixture.DISPLAY_MAX_COLUMNS,
         )
 
-    def _check_data_types(self, key, obtained_column, expected_column):
+    def _check_data_types(
+        self, key: Any, obtained_column: Any, expected_column: Any
+    ) -> None:
         """
         Check if data type of obtained and expected columns are the same. Fail if not.
         Helper method used in _check_fn method.
@@ -63,7 +70,7 @@ class DataFrameRegressionFixture:
             )
             raise AssertionError(error_msg)
 
-    def _check_data_shapes(self, obtained_column, expected_column):
+    def _check_data_shapes(self, obtained_column: Any, expected_column: Any) -> None:
         """
         Check if obtained and expected columns have the same size.
         Helper method used in _check_fn method.
@@ -80,12 +87,9 @@ class DataFrameRegressionFixture:
             )
             raise AssertionError(error_msg)
 
-    def _check_fn(self, obtained_filename, expected_filename):
+    def _check_fn(self, obtained_filename: Path, expected_filename: Path) -> None:
         """
         Check if dict contents dumped to a file match the contents in expected file.
-
-        :param str obtained_filename:
-        :param str expected_filename:
         """
         try:
             import numpy as np
@@ -169,12 +173,9 @@ class DataFrameRegressionFixture:
                 )
             raise AssertionError(error_msg)
 
-    def _dump_fn(self, data_object, filename):
+    def _dump_fn(self, data_object: Any, filename: Path) -> None:
         """
         Dump dict contents to the given filename
-
-        :param pd.DataFrame data_object:
-        :param str filename:
         """
         data_object.to_csv(
             str(filename),
@@ -183,12 +184,12 @@ class DataFrameRegressionFixture:
 
     def check(
         self,
-        data_frame,
-        basename=None,
-        fullpath=None,
-        tolerances=None,
-        default_tolerance=None,
-    ):
+        data_frame: Any,
+        basename: Optional[str] = None,
+        fullpath: Optional[Path] = None,
+        tolerances: Optional[Dict[str, Dict[str, float]]] = None,
+        default_tolerance: Optional[Dict[str, float]] = None,
+    ) -> None:
         """
         Checks a pandas dataframe, containing only numeric data, against a previously recorded version, or generate a new file.
 
@@ -203,21 +204,21 @@ class DataFrameRegressionFixture:
             })
             dataframe_regression.check(data_frame)
 
-        :param pandas.DataFrame data_frame: pandas DataFrame containing data for regression check.
+        :param data_frame: pandas DataFrame containing data for regression check.
 
-        :param str basename: basename of the file to test/record. If not given the name
+        :param basename: basename of the file to test/record. If not given the name
             of the test is used.
 
-        :param str fullpath: complete path to use as a reference file. This option
+        :param fullpath: complete path to use as a reference file. This option
             will ignore embed_data completely, being useful if a reference file is located
             in the session data dir for example.
 
-        :param dict tolerances: dict mapping keys from the data_frame to tolerance settings for the
+        :param tolerances: dict mapping keys from the data_frame to tolerance settings for the
             given data. Example::
 
-                tolerances={'U': Tolerance(atol=1e-2)}
+                tolerances={'U': dict(atol=1e-2)}
 
-        :param dict default_tolerance: dict mapping the default tolerance for the current check
+        :param default_tolerance: dict mapping the default tolerance for the current check
             call. Example::
 
                 default_tolerance=dict(atol=1e-7, rtol=1e-18).

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -1,9 +1,9 @@
 # mypy: disallow-untyped-defs
+import os
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Union
 
 import pytest
 
@@ -187,7 +187,7 @@ class DataFrameRegressionFixture:
         self,
         data_frame: Any,
         basename: Optional[str] = None,
-        fullpath: Optional[Union[Path, str]] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
     ) -> None:

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import pytest
 
@@ -186,7 +187,7 @@ class DataFrameRegressionFixture:
         self,
         data_frame: Any,
         basename: Optional[str] = None,
-        fullpath: Optional[Path] = None,
+        fullpath: Optional[Union[Path, str]] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
     ) -> None:

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import os
 from pathlib import Path
 from typing import Any

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -1,4 +1,5 @@
 # mypy: disallow-untyped-defs
+import os
 from functools import partial
 from pathlib import Path
 from typing import Callable
@@ -32,9 +33,9 @@ class FileRegressionFixture:
         extension: str = ".txt",
         newline: Optional[str] = None,
         basename: Optional[str] = None,
-        fullpath: Optional[Union[Path, str]] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
         binary: bool = False,
-        obtained_filename: Optional[Union[Path, str]] = None,
+        obtained_filename: Optional["os.PathLike[str]"] = None,
         check_fn: Optional[Callable[[Path, Path], None]] = None,
     ) -> None:
         """

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -32,9 +32,9 @@ class FileRegressionFixture:
         extension: str = ".txt",
         newline: Optional[str] = None,
         basename: Optional[str] = None,
-        fullpath: Optional[Path] = None,
+        fullpath: Optional[Union[Path, str]] = None,
         binary: bool = False,
-        obtained_filename: Optional[Path] = None,
+        obtained_filename: Optional[Union[Path, str]] = None,
         check_fn: Optional[Callable[[Path, Path], None]] = None,
     ) -> None:
         """

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import os
 from functools import partial
 from pathlib import Path

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -68,8 +68,6 @@ class FileRegressionFixture:
                 type(contents).__name__
             )
 
-        import io
-
         if check_fn is None:
 
             if binary:

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -1,4 +1,11 @@
+# mypy: disallow-untyped-defs
 from functools import partial
+from pathlib import Path
+from typing import Callable
+from typing import Optional
+from typing import Union
+
+import pytest
 
 from .common import check_text_files
 from .common import perform_regression_check
@@ -9,12 +16,9 @@ class FileRegressionFixture:
     Implementation of `file_regression` fixture.
     """
 
-    def __init__(self, datadir, original_datadir, request):
-        """
-        :type datadir: Path
-        :type original_datadir: Path
-        :type request: FixtureRequest
-        """
+    def __init__(
+        self, datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+    ) -> None:
         self.request = request
         self.datadir = datadir
         self.original_datadir = original_datadir
@@ -23,24 +27,24 @@ class FileRegressionFixture:
 
     def check(
         self,
-        contents,
-        encoding=None,
-        extension=".txt",
-        newline=None,
-        basename=None,
-        fullpath=None,
-        binary=False,
-        obtained_filename=None,
-        check_fn=None,
-    ):
+        contents: Union[str, bytes],
+        encoding: Optional[str] = None,
+        extension: str = ".txt",
+        newline: Optional[str] = None,
+        basename: Optional[str] = None,
+        fullpath: Optional[Path] = None,
+        binary: bool = False,
+        obtained_filename: Optional[Path] = None,
+        check_fn: Optional[Callable[[Path, Path], None]] = None,
+    ) -> None:
         """
         Checks the contents against a previously recorded version, or generate a new file.
 
-        :param str contents: content to be verified.
-        :param str|None encoding: Encoding used to write file, if any.
-        :param str extension: Extension of file.
-        :param str|None newline: See `io.open` docs.
-        :param bool binary: If the file is binary or text.
+        :param contents: content to be verified.
+        :param encoding: Encoding used to write file, if any.
+        :param extension: Extension of file.
+        :param newline: See `io.open` docs.
+        :param binary: If the file is binary or text.
         :param obtained_filename: ..see:: FileRegressionCheck
         :param check_fn: a function with signature ``(obtained_filename, expected_filename)`` that should raise
             AssertionError if both files differ.
@@ -72,7 +76,7 @@ class FileRegressionFixture:
 
             if binary:
 
-                def check_fn(obtained_filename, expected_filename):
+                def check_fn(obtained_filename: Path, expected_filename: Path) -> None:
                     if obtained_filename.read_bytes() != expected_filename.read_bytes():
                         raise AssertionError(
                             "Binary files {} and {} differ.".format(
@@ -83,11 +87,12 @@ class FileRegressionFixture:
             else:
                 check_fn = partial(check_text_files, encoding=encoding)
 
-        def dump_fn(filename):
+        def dump_fn(filename: Path) -> None:
             mode = "wb" if binary else "w"
             with open(str(filename), mode, encoding=encoding, newline=newline) as f:
                 f.write(contents)
 
+        assert check_fn is not None
         perform_regression_check(
             datadir=self.datadir,
             original_datadir=self.original_datadir,

--- a/src/pytest_regressions/image_regression.py
+++ b/src/pytest_regressions/image_regression.py
@@ -1,10 +1,10 @@
 # mypy: disallow-untyped-defs
 import io
+import os
 from functools import partial
 from pathlib import Path
 from typing import Any
 from typing import Optional
-from typing import Union
 
 import pytest
 
@@ -26,7 +26,7 @@ class ImageRegressionFixture:
         self.force_regen = False
         self.with_test_class_names = False
 
-    def _load_image(self, filename: Union[Path, str]) -> Any:
+    def _load_image(self, filename: "os.PathLike[str]") -> Any:
         """
         Reads the image from the given file and convert it to RGB if necessary.
         This is necessary to be used with the ImageChops module operations.

--- a/src/pytest_regressions/image_regression.py
+++ b/src/pytest_regressions/image_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import io
 import os
 from functools import partial

--- a/src/pytest_regressions/image_regression.py
+++ b/src/pytest_regressions/image_regression.py
@@ -1,8 +1,15 @@
+# mypy: disallow-untyped-defs
 import io
 from functools import partial
+from pathlib import Path
+from typing import Any
+from typing import Optional
+from typing import Union
 
-from pytest_regressions.common import import_error_message
-from pytest_regressions.common import perform_regression_check
+import pytest
+
+from .common import import_error_message
+from .common import perform_regression_check
 
 
 class ImageRegressionFixture:
@@ -10,27 +17,21 @@ class ImageRegressionFixture:
     Regression test for image objects, accounting for small differences.
     """
 
-    def __init__(self, datadir, original_datadir, request):
-        """
-        :type datadir: Path
-        :type original_datadir: Path
-        :type request: FixtureRequest
-        """
+    def __init__(
+        self, datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+    ) -> None:
         self.request = request
         self.datadir = datadir
         self.original_datadir = original_datadir
         self.force_regen = False
         self.with_test_class_names = False
 
-    def _load_image(self, filename):
+    def _load_image(self, filename: Union[Path, str]) -> Any:
         """
         Reads the image from the given file and convert it to RGB if necessary.
         This is necessary to be used with the ImageChops module operations.
         At this time, in this module, channel operations are only implemented
         for 8-bit images (e.g. "L" and "RGB").
-
-        :param Path filename:
-            The name of the file
         """
         try:
             from PIL import Image
@@ -43,11 +44,11 @@ class ImageRegressionFixture:
         else:
             return img
 
-    def _compute_manhattan_distance(self, diff_image):
+    def _compute_manhattan_distance(self, diff_image: Any) -> float:
         """
         Computes a percentage of similarity of the difference image given.
 
-        :param PIL.Image diff_image:
+        :param diff_image:
             An image in RGB mode computed from ImageChops.difference
         """
         try:
@@ -56,7 +57,7 @@ class ImageRegressionFixture:
             raise ModuleNotFoundError(import_error_message("Numpy"))
 
         number_of_pixels = diff_image.size[0] * diff_image.size[1]
-        return (
+        return float(
             # To obtain a number in 0.0 -> 100.0
             100.0
             * (
@@ -71,24 +72,28 @@ class ImageRegressionFixture:
         )
 
     def _check_images_manhattan_distance(
-        self, obtained_file, expected_file, expect_equal, diff_threshold
-    ):
+        self,
+        obtained_file: Path,
+        expected_file: Path,
+        expect_equal: bool,
+        diff_threshold: float,
+    ) -> None:
         """
         Compare two image by computing the differences spatially, pixel by pixel.
 
         The Manhattan Distance is used to compute how much two images differ.
 
-        :param str obtained_file:
+        :param obtained_file:
             The image with the obtained image
 
-        :param str expected_files:
+        :param expected_file:
             The image with the expected image
 
-        :param bool expected_equal:
+        :param expect_equal:
             If True, the images are expected to be equal, otherwise, they're expected to be
             different.
 
-        :param float diff_threshold:
+        :param diff_threshold:
             The maximum percentage of difference accepted.
             A value between 0.0 and 100.0
 
@@ -106,17 +111,16 @@ class ImageRegressionFixture:
         obtained_img = self._load_image(obtained_file)
         expected_img = self._load_image(expected_file)
 
-        def check_result(equal, manhattan_distance):
+        def check_result(equal: bool, manhattan_distance: Optional[float]) -> None:
             if equal != expect_equal:
-                params = manhattan_distance, expected_file, obtained_file
                 if expect_equal:
-                    assert 0, (
-                        "Difference between images too high: %.2f %%\n%s\n%s" % params
-                    )
+                    assert (
+                        False
+                    ), f"Difference between images too high: {manhattan_distance} %\n{expected_file}\n{obtained_file}"
                 else:
-                    assert 0, (
-                        "Difference between images too small: %.2f %%\n%s\n%s" % params
-                    )
+                    assert (
+                        False
+                    ), f"Difference between images too small: {manhattan_distance} %\n{expected_file}\n{obtained_file}"
 
         # 1st check: identical
         diff_img = ImageChops.difference(obtained_img, expected_img)
@@ -128,18 +132,23 @@ class ImageRegressionFixture:
         equal = manhattan_distance <= diff_threshold
         check_result(equal, manhattan_distance)
 
-    def check(self, image_data, diff_threshold=0.1, expect_equal=True, basename=None):
+    def check(
+        self,
+        image_data: bytes,
+        diff_threshold: float = 0.1,
+        expect_equal: bool = True,
+        basename: Optional[str] = None,
+    ) -> None:
         """
         Checks that the given image contents are comparable with the ones stored in the data directory.
 
-        :param bytes image_data: image data
-        :param str|None basename: basename to store the information in the data directory. If none, use the name
+        :param image_data: image data
+        :param basename: basename to store the information in the data directory. If none, use the name
             of the test function.
-        :param bool expect_equal: if the image should considered equal below of the given threshold. If False, the
+        :param expect_equal: if the image should considered equal below of the given threshold. If False, the
             image should be considered different at least above the threshold.
-        :param float diff_threshold:
-            Tolerage as a percentage (1 to 100) on how the images are allowed to differ.
-
+        :param diff_threshold:
+            Tolerance as a percentage (1 to 100) on how the images are allowed to differ.
         """
         __tracebackhide__ = True
 
@@ -148,7 +157,7 @@ class ImageRegressionFixture:
         except ModuleNotFoundError:
             raise ModuleNotFoundError(import_error_message("Pillow"))
 
-        def dump_fn(target):
+        def dump_fn(target: Path) -> None:
             image = Image.open(io.BytesIO(image_data))
             image.save(str(target), "PNG")
 

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import os
 import zipfile
 from pathlib import Path

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -1,10 +1,10 @@
 # mypy: disallow-untyped-defs
+import os
 import zipfile
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Optional
-from typing import Union
 
 import pytest
 
@@ -274,7 +274,7 @@ class NDArraysRegressionFixture:
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Union[Path, str]] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
     ) -> None:

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -1,4 +1,5 @@
 import zipfile
+from typing import Any
 
 from pytest_regressions.common import import_error_message
 from pytest_regressions.common import perform_regression_check
@@ -131,6 +132,7 @@ class NDArraysRegressionFixture:
                 not_close_mask = obtained_array != expected_array
 
             if np.any(not_close_mask):
+                diff_ids: Any
                 if not_close_mask.ndim == 0:
                     diff_ids = [()]
                 else:

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import pytest
 
@@ -273,7 +274,7 @@ class NDArraysRegressionFixture:
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Path] = None,
+        fullpath: Optional[Union[Path, str]] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
     ) -> None:

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -1,10 +1,9 @@
 # mypy: disallow-untyped-defs
-from pathlib import Path
+import os
 from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
-from typing import Union
 
 from .common import import_error_message
 from .dataframe_regression import DataFrameRegressionFixture
@@ -19,7 +18,7 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Union[Path, str]] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
         data_index: Optional[Sequence[int]] = None,

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -1,5 +1,4 @@
 from pytest_regressions.common import import_error_message
-from pytest_regressions.common import perform_regression_check
 from pytest_regressions.dataframe_regression import DataFrameRegressionFixture
 
 
@@ -81,7 +80,7 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
                 if np.issubdtype(arr.dtype, np.number):
                     data_dict[k] = arr
 
-        data_shapes = []
+        data_shapes1 = []
         for obj in data_dict.values():
             assert type(obj) in [
                 np.ndarray
@@ -92,10 +91,10 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
                 "Only 1D arrays are supported on num_data_regression fixture.\n"
                 "Array with shape %s was given.\n" % (shape,)
             )
-            data_shapes.append(shape[0])
+            data_shapes1.append(shape[0])
 
-        data_shapes = np.array(data_shapes)
-        if not np.all(data_shapes == data_shapes[0]):
+        data_shapes2 = np.array(data_shapes1)
+        if not np.all(data_shapes2 == data_shapes2[0]):
             if not fill_different_shape_with_nan:
                 assert (
                     False
@@ -107,7 +106,7 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
                     "Checking multiple arrays with different shapes are not supported for non-float arrays"
                 )
             else:
-                max_size = max(data_shapes)
+                max_size = max(data_shapes2)
                 for k, obj in data_dict.items():
                     new_data = np.empty(shape=(max_size,), dtype=obj.dtype)
                     new_data[: len(obj)] = obj

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Sequence
+from typing import Union
 
 from .common import import_error_message
 from .dataframe_regression import DataFrameRegressionFixture
@@ -18,7 +19,7 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
         self,
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
-        fullpath: Optional[Path] = None,
+        fullpath: Optional[Union[Path, str]] = None,
         tolerances: Optional[Dict[str, Dict[str, float]]] = None,
         default_tolerance: Optional[Dict[str, float]] = None,
         data_index: Optional[Sequence[int]] = None,

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -1,5 +1,12 @@
-from pytest_regressions.common import import_error_message
-from pytest_regressions.dataframe_regression import DataFrameRegressionFixture
+# mypy: disallow-untyped-defs
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+
+from .common import import_error_message
+from .dataframe_regression import DataFrameRegressionFixture
 
 
 class NumericRegressionFixture(DataFrameRegressionFixture):
@@ -9,14 +16,14 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
 
     def check(
         self,
-        data_dict,
-        basename=None,
-        fullpath=None,
-        tolerances=None,
-        default_tolerance=None,
-        data_index=None,
-        fill_different_shape_with_nan=True,
-    ):
+        data_dict: Dict[str, Any],
+        basename: Optional[str] = None,
+        fullpath: Optional[Path] = None,
+        tolerances: Optional[Dict[str, Dict[str, float]]] = None,
+        default_tolerance: Optional[Dict[str, float]] = None,
+        data_index: Optional[Sequence[int]] = None,
+        fill_different_shape_with_nan: bool = True,
+    ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.
         The dict must map from user-defined keys to 1d numpy arrays or array-like values.
@@ -31,32 +38,32 @@ class NumericRegressionFixture(DataFrameRegressionFixture):
                 'P': Pa_to_bar(P)[positions],
             })
 
-        :param dict data_dict: dict mapping keys to numpy arrays, or objects that can be
+        :param data_dict: dict mapping keys to numpy arrays, or objects that can be
             coerced to 1d numpy arrays with a numeric dtype (e.g. list, tuple, etc).
 
-        :param str basename: basename of the file to test/record. If not given the name
+        :param basename: basename of the file to test/record. If not given the name
             of the test is used.
 
-        :param str fullpath: complete path to use as a reference file. This option
+        :param fullpath: complete path to use as a reference file. This option
             will ignore embed_data completely, being useful if a reference file is located
             in the session data dir for example.
 
-        :param dict tolerances: dict mapping keys from the data_dict to tolerance settings for the
+        :param tolerances: dict mapping keys from the data_dict to tolerance settings for the
             given data. Example::
 
                 tolerances={'U': Tolerance(atol=1e-2)}
 
-        :param dict default_tolerance: dict mapping the default tolerance for the current check
+        :param default_tolerance: dict mapping the default tolerance for the current check
             call. Example::
 
                 default_tolerance=dict(atol=1e-7, rtol=1e-18).
 
             If not provided, will use defaults from numpy's ``isclose`` function.
 
-        :param list data_index: If set, will override the indexes shown in the outputs. Default
+        :param data_index: If set, will override the indexes shown in the outputs. Default
             is panda's default, which is ``range(0, len(data))``.
 
-        :param bool fill_different_shape_with_nan: If set, all the data provided in the data_dict
+        :param fill_different_shape_with_nan: If set, all the data provided in the data_dict
             that has size lower than the bigger size will be filled with ``np.NaN``, in order to save
             the data in a CSV file.
 

--- a/src/pytest_regressions/num_regression.py
+++ b/src/pytest_regressions/num_regression.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 import os
 from typing import Any
 from typing import Dict

--- a/src/pytest_regressions/plugin.py
+++ b/src/pytest_regressions/plugin.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/src/pytest_regressions/plugin.py
+++ b/src/pytest_regressions/plugin.py
@@ -1,7 +1,19 @@
+# mypy: disallow-untyped-defs
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
 
+if TYPE_CHECKING:
+    from .data_regression import DataRegressionFixture
+    from .dataframe_regression import DataFrameRegressionFixture
+    from .ndarrays_regression import NDArraysRegressionFixture
+    from .file_regression import FileRegressionFixture
+    from .num_regression import NumericRegressionFixture
+    from .image_regression import ImageRegressionFixture
 
-def pytest_addoption(parser):
+
+def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("regressions")
     group.addoption(
         "--force-regen",
@@ -24,7 +36,9 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def data_regression(datadir, original_datadir, request):
+def data_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "DataRegressionFixture":
     """
     Fixture used to test arbitrary data against known versions previously
     recorded by this same fixture. Useful to test 3rd party APIs or where testing directly
@@ -41,11 +55,6 @@ def data_regression(datadir, original_datadir, request):
     the new changes are expected and not regressions.
 
     The dict may be anything serializable by the `yaml` library.
-
-    :type datadir: Path
-    :type request: FixtureRequest
-    :rtype: DataRegressionFixture
-    :return: Data regression fixture.
     """
     from .data_regression import DataRegressionFixture
 
@@ -53,7 +62,9 @@ def data_regression(datadir, original_datadir, request):
 
 
 @pytest.fixture
-def dataframe_regression(datadir, original_datadir, request):
+def dataframe_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "DataFrameRegressionFixture":
     """
     Example usage:
 
@@ -70,11 +81,6 @@ def dataframe_regression(datadir, original_datadir, request):
             ),
             default_tolerance=dict(atol=1e-8, rtol=1e-8)
         )
-
-    :type embed_data: _EmbedDataFixture
-    :type request: FixtureRequest
-    :rtype: DataRegressionFixture
-    :return: Data regression fixture.
     """
     from .dataframe_regression import DataFrameRegressionFixture
 
@@ -82,7 +88,9 @@ def dataframe_regression(datadir, original_datadir, request):
 
 
 @pytest.fixture
-def ndarrays_regression(datadir, original_datadir, request):
+def ndarrays_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "NDArraysRegressionFixture":
     """
     Similar to num_regression, but supports numpy arrays with arbitrary shape. The
     dictionary is stored as an NPZ file. The values of the dictionary must be accepted
@@ -99,11 +107,6 @@ def ndarrays_regression(datadir, original_datadir, request):
                 },
                 default_tolerance=dict(atol=1e-8, rtol=1e-8)
             )
-
-    :type embed_data: _EmbedDataFixture
-    :type request: FixtureRequest
-    :rtype: DataRegressionFixture
-    :return: Data regression fixture.
     """
     from .ndarrays_regression import NDArraysRegressionFixture
 
@@ -111,17 +114,14 @@ def ndarrays_regression(datadir, original_datadir, request):
 
 
 @pytest.fixture
-def file_regression(datadir, original_datadir, request):
+def file_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "FileRegressionFixture":
     """
     Very similar to `data_regression`, but instead of saving data to YAML file it saves to an
     arbitrary format.
 
     Useful when used to compare contents of files of specific format (like documents, for instance).
-
-    :type embed_data: _EmbedDataFixture
-    :type request: FixtureRequest
-    :rtype: FileRegressionFixture
-    :return: File regression fixture.
     """
     from .file_regression import FileRegressionFixture
 
@@ -129,7 +129,9 @@ def file_regression(datadir, original_datadir, request):
 
 
 @pytest.fixture
-def num_regression(datadir, original_datadir, request):
+def num_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "NumericRegressionFixture":
     """
     Example usage:
 
@@ -145,11 +147,6 @@ def num_regression(datadir, original_datadir, request):
             data_index=positions,
             default_tolerance=dict(atol=1e-8, rtol=1e-8)
         )
-
-    :type embed_data: _EmbedDataFixture
-    :type request: FixtureRequest
-    :rtype: DataRegressionFixture
-    :return: Data regression fixture.
     """
     from .num_regression import NumericRegressionFixture
 
@@ -157,7 +154,9 @@ def num_regression(datadir, original_datadir, request):
 
 
 @pytest.fixture
-def image_regression(datadir, original_datadir, request):
+def image_regression(
+    datadir: Path, original_datadir: Path, request: pytest.FixtureRequest
+) -> "ImageRegressionFixture":
     """
     Regression checks for images, accounting for small differences between them.
 

--- a/src/pytest_regressions/testing.py
+++ b/src/pytest_regressions/testing.py
@@ -1,15 +1,21 @@
+# mypy: disallow-untyped-defs
 import operator
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+import pytest
 
 
 def check_regression_fixture_workflow(
-    testdir,
-    source,
-    data_getter,
-    data_modifier,
-    expected_data_1,
-    expected_data_2,
-    compare_fn=None,
-):
+    pytester: pytest.Pytester,
+    source: str,
+    data_getter: Callable[[], Any],
+    data_modifier: Callable[[], Any],
+    expected_data_1: Any,
+    expected_data_2: Any,
+    compare_fn: Optional[Callable[[object, object], bool]] = None,
+) -> None:
     """
     Helper method to test regression fixtures like `data_regression`. Offers a basic template/script
     able to validate main behaviors expected by regression fixtures.
@@ -35,7 +41,7 @@ def check_regression_fixture_workflow(
             return f.read()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source,
         data_getter=get_data,
         data_modifier=lambda: monkeypatch.setattr(sys, 'get_data', lambda: 'bar', raising=False),
@@ -44,7 +50,7 @@ def check_regression_fixture_workflow(
     )
     ```
 
-    :param Testdir testdir: `testdir` fixture. Requires pytest's `pytester` to be installed.
+    :param pytester: pytester fixture.
     :param str source: Source code using regression fixture.
     :param callable data_getter: Function without arguments that returns contents of file
         created by regression test when it fails first time (i.e. the expected file for future
@@ -58,30 +64,31 @@ def check_regression_fixture_workflow(
         to compare numpy arrays).
     """
     if compare_fn is None:
+        # TODO review this.
         compare_fn = operator.eq
-    testdir.makepyfile(test_file=source)
+    pytester.makepyfile(test_file=source)
 
     # First run fails because there's no expected file yet
-    result = testdir.inline_run()
+    result = pytester.inline_run()
     result.assertoutcome(failed=1)
 
     # ensure now that the file was generated and the test passes
     xx = data_getter()
     compare_fn(xx, expected_data_1)
-    result = testdir.inline_run()
+    result = pytester.inline_run()
     result.assertoutcome(passed=1)
 
     # changing the regression data makes the test fail (file remains unchanged)
     data_modifier()
-    result = testdir.inline_run()
+    result = pytester.inline_run()
     result.assertoutcome(failed=1)
     compare_fn(data_getter(), expected_data_1)
 
     # force regeneration (test fails again)
-    result = testdir.inline_run("--force-regen")
+    result = pytester.inline_run("--force-regen")
     result.assertoutcome(failed=1)
     compare_fn(data_getter(), expected_data_2)
 
     # test should pass again
-    result = testdir.inline_run()
+    result = pytester.inline_run()
     result.assertoutcome(passed=1)

--- a/src/pytest_regressions/testing.py
+++ b/src/pytest_regressions/testing.py
@@ -1,4 +1,3 @@
-# mypy: disallow-untyped-defs
 from typing import Any
 from typing import Callable
 from typing import Optional

--- a/tests/test_dataframe_regression.py
+++ b/tests/test_dataframe_regression.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,15 +13,7 @@ def no_regen(dataframe_regression, request):
         pytest.fail("--force-regen should not be used on this test.")
 
 
-def test_usage_workflow(testdir, monkeypatch):
-    """
-    :type testdir: _pytest.pytester.TmpTestdir
-
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
-
-    import sys
-
+def test_usage_workflow(pytester, monkeypatch):
     monkeypatch.setattr(
         sys, "testing_get_data", lambda: {"data": 1.1 * np.ones(50)}, raising=False
     )
@@ -32,7 +26,7 @@ def test_usage_workflow(testdir, monkeypatch):
     """
 
     def get_csv_contents():
-        filename = testdir.tmpdir / "test_file" / "test_1.csv"
+        filename = pytester.path / "test_file" / "test_1.csv"
         frame = pd.read_csv(str(filename))
         return {"data": frame["data"].values}
 
@@ -40,7 +34,7 @@ def test_usage_workflow(testdir, monkeypatch):
         assert (obtained["data"] == expected["data"]).all()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source=source,
         data_getter=get_csv_contents,
         data_modifier=lambda: monkeypatch.setattr(

--- a/tests/test_file_regression.py
+++ b/tests/test_file_regression.py
@@ -1,5 +1,5 @@
+import sys
 import textwrap
-from pathlib import Path
 
 import pytest
 
@@ -26,12 +26,7 @@ def test_binary_and_text_error(file_regression):
         file_regression.check("", encoding="UTF-8", binary=True)
 
 
-def test_file_regression_workflow(testdir, monkeypatch):
-    """
-    :type testdir: _pytest.pytester.TmpTestdir
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
-    import sys
+def test_file_regression_workflow(pytester, monkeypatch):
 
     monkeypatch.setattr(sys, "get_data", lambda: "foo", raising=False)
     source = """
@@ -42,12 +37,12 @@ def test_file_regression_workflow(testdir, monkeypatch):
     """
 
     def get_file_contents():
-        fn = Path(str(testdir.tmpdir)) / "test_file" / "test_1.test"
+        fn = pytester.path / "test_file" / "test_1.test"
         assert fn.is_file()
         return fn.read_text()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source,
         data_getter=get_file_contents,
         data_modifier=lambda: monkeypatch.setattr(

--- a/tests/test_file_regression.py
+++ b/tests/test_file_regression.py
@@ -1,8 +1,8 @@
 import textwrap
+from pathlib import Path
 
 import pytest
 
-from pytest_regressions.common import Path
 from pytest_regressions.testing import check_regression_fixture_workflow
 
 

--- a/tests/test_filenames.py
+++ b/tests/test_filenames.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 

--- a/tests/test_image_regression.py
+++ b/tests/test_image_regression.py
@@ -1,7 +1,7 @@
 import io
 from functools import partial
+from pathlib import Path
 
-from pytest_regressions.common import Path
 from pytest_regressions.testing import check_regression_fixture_workflow
 
 

--- a/tests/test_image_regression.py
+++ b/tests/test_image_regression.py
@@ -1,6 +1,5 @@
 import io
 from functools import partial
-from pathlib import Path
 
 from pytest_regressions.testing import check_regression_fixture_workflow
 
@@ -33,11 +32,7 @@ def test_image_regression(image_regression, datadir):
     image_regression.check(image_filename.read_bytes(), diff_threshold=1.0)
 
 
-def test_image_regression_workflow(testdir, monkeypatch, datadir):
-    """
-    :type testdir: _pytest.pytester.TmpTestdir
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
+def test_image_regression_workflow(pytester, monkeypatch, datadir):
     import sys
     from PIL import Image
 
@@ -56,12 +51,12 @@ def test_image_regression_workflow(testdir, monkeypatch, datadir):
     """
 
     def get_file_contents():
-        fn = Path(str(testdir.tmpdir)) / "test_file" / "test_1.png"
+        fn = pytester.path / "test_file" / "test_1.png"
         assert fn.is_file()
         return fn.read_bytes()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source,
         data_getter=get_file_contents,
         data_modifier=lambda: monkeypatch.setattr(

--- a/tests/test_image_regression.py
+++ b/tests/test_image_regression.py
@@ -62,6 +62,6 @@ def test_image_regression_workflow(pytester, monkeypatch, datadir):
         data_modifier=lambda: monkeypatch.setattr(
             sys, "get_image", partial(get_image, "black"), raising=False
         ),
-        expected_data_1=partial(get_image, "white"),
-        expected_data_2=partial(get_image, "black"),
+        expected_data_1=get_image("white"),
+        expected_data_2=get_image("black"),
     )

--- a/tests/test_ndarrays_regression.py
+++ b/tests/test_ndarrays_regression.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import numpy as np
 import pytest
@@ -375,7 +374,7 @@ def test_complex_array(ndarrays_regression, no_regen):
     data1 = np.array([3.0 + 2.5j, 0.5, -1.879])
     with pytest.raises(AssertionError) as excinfo:
         ndarrays_regression.check({"data1": data1})
-    obtained_error_msg = str(excinfo.value)
+    str(excinfo.value)
     expected = "\n".join(
         [
             "data1:",
@@ -458,13 +457,13 @@ def test_arrays_with_different_shapes(ndarrays_regression):
 
 def test_scalars(ndarrays_regression):
     # Initial data with scalars.
-    data = {"data1": 4.0, "data2": 42}
-    ndarrays_regression.check(data)
+    data1 = {"data1": 4.0, "data2": 42}
+    ndarrays_regression.check(data1)
 
     # Run check with non-scalar data.
-    data = {"data1": np.array([4.0]), "data2": np.array([42, 21])}
+    data2 = {"data1": np.array([4.0]), "data2": np.array([42, 21])}
     with pytest.raises(AssertionError) as excinfo:
-        ndarrays_regression.check(data)
+        ndarrays_regression.check(data2)
     obtained_error_msg = str(excinfo.value)
     expected = "\n".join(
         [
@@ -477,9 +476,9 @@ def test_scalars(ndarrays_regression):
     assert expected in obtained_error_msg
 
     # Other test case.
-    data = {"data1": 5.0, "data2": 21}
+    data3 = {"data1": 5.0, "data2": 21}
     with pytest.raises(AssertionError) as excinfo:
-        ndarrays_regression.check(data)
+        ndarrays_regression.check(data3)
     obtained_error_msg = str(excinfo.value)
     expected = "\n".join(
         [

--- a/tests/test_ndarrays_regression.py
+++ b/tests/test_ndarrays_regression.py
@@ -1,4 +1,4 @@
-import os
+import sys
 
 import numpy as np
 import pytest
@@ -12,14 +12,7 @@ def no_regen(ndarrays_regression, request):
         pytest.fail("--force-regen should not be used on this test.")
 
 
-def test_usage_workflow(testdir, monkeypatch):
-    """
-    :type testdir: _pytest.pytester.TmpTestdir
-
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
-
-    import sys
+def test_usage_workflow(pytester, monkeypatch):
 
     monkeypatch.setattr(
         sys, "testing_get_data", lambda: {"data": 1.1 * np.ones(50)}, raising=False
@@ -32,14 +25,14 @@ def test_usage_workflow(testdir, monkeypatch):
     """
 
     def get_npz_contents():
-        filename = testdir.tmpdir / "test_file" / "test_1.npz"
+        filename = pytester.path / "test_file" / "test_1.npz"
         return dict(np.load(str(filename)))
 
     def compare_arrays(obtained, expected):
         assert (obtained["data"] == expected["data"]).all()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source=source,
         data_getter=get_npz_contents,
         data_modifier=lambda: monkeypatch.setattr(
@@ -624,9 +617,9 @@ def test_missing_obtained(ndarrays_regression):
 
 
 @pytest.mark.parametrize("prefix", [True, False])
-def test_corrupt_npz(ndarrays_regression, tmpdir, prefix):
+def test_corrupt_npz(ndarrays_regression, tmp_path, prefix):
     data = {"data1": np.array([4, 5])}
-    fn_npz = os.path.join(tmpdir, "corrupt.npz")
+    fn_npz = tmp_path / "corrupt.npz"
     # Write random bytes to a file
     with open(fn_npz, "wb") as f:
         if prefix:

--- a/tests/test_num_regression.py
+++ b/tests/test_num_regression.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,15 +13,7 @@ def no_regen(num_regression, request):
         pytest.fail("--force-regen should not be used on this test.")
 
 
-def test_usage_workflow(testdir, monkeypatch):
-    """
-    :type testdir: _pytest.pytester.TmpTestdir
-
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
-
-    import sys
-
+def test_usage_workflow(pytester, monkeypatch):
     monkeypatch.setattr(
         sys, "testing_get_data", lambda: {"data": 1.1 * np.ones(50)}, raising=False
     )
@@ -31,7 +25,7 @@ def test_usage_workflow(testdir, monkeypatch):
     """
 
     def get_csv_contents():
-        filename = testdir.tmpdir / "test_file" / "test_1.csv"
+        filename = pytester.path / "test_file" / "test_1.csv"
         frame = pd.read_csv(str(filename))
         return {"data": frame["data"].values}
 
@@ -39,7 +33,7 @@ def test_usage_workflow(testdir, monkeypatch):
         assert (obtained["data"] == expected["data"]).all()
 
     check_regression_fixture_workflow(
-        testdir,
+        pytester,
         source=source,
         data_getter=get_csv_contents,
         data_modifier=lambda: monkeypatch.setattr(


### PR DESCRIPTION
* Also require pytest 6.2+ so we can use modern `pytester` and `tmp_path` fixtures.