### PR TITLE
Create GitHub release after deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,15 +60,19 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: "3.7"
-    - name: Install wheel
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
+        pip install build
     - name: Build package
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.pypi_token }}
+    - name: GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: dist/*


### PR DESCRIPTION
Also modernize how the package is generated using `build` instead of deprecated `setup.py`.

Close #139