### PR TITLE
Release 2.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,27 +10,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
         include:
-          # non-matrix listed runs (python 3.6 is not supported with ubuntu-latest).
-          - python: 3.6
-            os: ubuntu-20.04
-            tox_env: "py36"
-          - python: 3.6
-            os: windows-latest
-            tox_env: "py36"
-          - python: "3.7"
-            tox_env: "py37"
           - python: "3.8"
             tox_env: "py38"
           - python: "3.9"
             tox_env: "py39"
           - python: "3.10"
             tox_env: "py310,pytest6"
-        exclude:
-          - python: "3.6"
-            os: windows-latest
+          - python: "3.11"
+            tox_env: "py311"
 
     steps:
     - uses: actions/checkout@v3
@@ -59,7 +49,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.7"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.5.0 (2023-08-31)
+------------------
+
+* Dropped support for EOL Python 3.6 and Python 3.7.
+* Added support for Python 3.11.
+
 2.4.3 (2023-08-30)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ def read(fname: str) -> str:
 setup(
     name="pytest-regressions",
     use_scm_version=True,
-    setup_requires=[
-        "setuptools_scm; python_version>'3.6'",
-        "setuptools_scm <7.0; python_version=='3.6'",
-    ],
+    setup_requires=["setuptools_scm"],
     author="ESSS",
     author_email="foss@esss.co",
     maintainer="Bruno Oliveira",
@@ -26,7 +23,7 @@ setup(
     long_description=read("README.rst"),
     packages=find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     package_data={
         "pytest_regressions": ["py.typed"],
     },
@@ -55,11 +52,10 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",

--- a/src/pytest_regressions/ndarrays_regression.py
+++ b/src/pytest_regressions/ndarrays_regression.py
@@ -253,7 +253,7 @@ class NDArraysRegressionFixture:
             with open(filename, "rb") as f:
                 result = dict(np.load(f))
         except (zipfile.BadZipFile, ValueError) as e:
-            raise IOError(
+            raise OSError(
                 f"NPZ file {filename} could not be loaded. Corrupt file?"
             ) from e
         return result

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pytest6, docs,linting
+envlist = py38,py39,py310,py311,pytest6
 
 [testenv]
 download = true


### PR DESCRIPTION
Drop EOL Python 3.6 and 3.7

Also execute pyupgrade --py38-plus.