### PR TITLE
docs: make the nature of content clearer

### DIFF
--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -40,11 +40,11 @@ class FileRegressionFixture:
         """
         Checks the contents against a previously recorded version, or generate a new file.
 
-        :param contents: content to be verified.
+        :param contents: content of the file to be verified as text or bytes. 
         :param encoding: Encoding used to write file, if any.
         :param extension: Extension of file.
         :param newline: See `io.open` docs.
-        :param binary: If the file is binary or text.
+        :param binary: If the provided content is binary or text.
         :param obtained_filename: ..see:: FileRegressionCheck
         :param check_fn: a function with signature ``(obtained_filename, expected_filename)`` that should raise
             AssertionError if both files differ.


### PR DESCRIPTION
In the end, the most misleading parameter for me was "binary" as it assumed I pass a file when I should instead pass the content of a file in a format that fits the data (bytes or text).

I updated the docstring to make it a bit clearer IMHO.

Fix #151 