### PR TITLE
feat: add a prescision parameter to data_regression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 UNRELEASED
 ----------
 
-* `#132 <https://github.com/ESSS/pytest-regressions/pull/132>`__: Add documentation for specifying custom data directories.
+* `#132 <https://github.com/ESSS/pytest-regressions/pull/132>`__: Added documentation for specifying custom data directories.
+* `#177 <https://github.com/ESSS/pytest-regressions/pull/177>`__: Added new `round_digits` to `data_regression.check`, which when given will round all float values to the given number of dicts (recursively) before saving the data to disk.
 
 2.5.0 (2023-08-31)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ UNRELEASED
 ----------
 
 * `#132 <https://github.com/ESSS/pytest-regressions/pull/132>`__: Added documentation for specifying custom data directories.
-* `#177 <https://github.com/ESSS/pytest-regressions/pull/177>`__: Added new `round_digits` to `data_regression.check`, which when given will round all float values to the given number of dicts (recursively) before saving the data to disk.
+* `#177 <https://github.com/ESSS/pytest-regressions/pull/177>`__: Added new ``round_digits`` to ``data_regression.check``, which when given will round all float values to the given number of dicts (recursively) before saving the data to disk.
 
 2.5.0 (2023-08-31)
 ------------------

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -197,7 +197,7 @@ def perform_regression_check(
 T = TypeVar("T", bound=Union[MutableSequence, MutableMapping])
 
 
-def round_digits(data: T, digits: int) -> T:
+def round_digits_in_data(data: T, digits: int) -> T:
     """
     Recursively round the values of any float value in a collection to the given number of digits. The rounding is done in-place.
 
@@ -216,7 +216,7 @@ def round_digits(data: T, digits: int) -> T:
     generator = enumerate(data) if isinstance(data, MutableSequence) else data.items()
     for k, v in generator:
         if isinstance(v, (MutableSequence, MutableMapping)):
-            data[k] = round_digits(v, digits)
+            data[k] = round_digits_in_data(v, digits)
         elif isinstance(v, float):
             data[k] = round(v, digits)
         else:

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -197,22 +197,28 @@ def perform_regression_check(
 T = TypeVar("T", bound=Union[MutableSequence, MutableMapping])
 
 
-def round_digits(data: T, precision: int) -> T:
+def round_digits(data: T, digits: int) -> T:
     """
-    Recursively Round the values of any float value in a collection to the given precision.
+    Recursively round the values of any float value in a collection to the given number of digits. The rounding is done in-place.
 
-    :param data: The collection to round.
-    :param precision: The number of decimal places to round to.
-    :return: The collection with all float values rounded to the given precision.
+    :param data: 
+        The collection to round.
 
+    :param digits: 
+        The number of digits to round to.
+    
+    :return: 
+        The collection with all float values rounded to the given precision.
+        Note that the rounding is done in-place, so this return value only exists
+        because we use the function recursively.
     """
-    # change the generator depending on the collection type
+    # Change the generator depending on the collection type.
     generator = enumerate(data) if isinstance(data, MutableSequence) else data.items()
     for k, v in generator:
         if isinstance(v, (MutableSequence, MutableMapping)):
-            data[k] = round_digits(v, precision)
+            data[k] = round_digits(v, digits)
         elif isinstance(v, float):
-            data[k] = round(v, precision)
+            data[k] = round(v, digits)
         else:
             data[k] = v
     return data

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable
 from typing import List
 from typing import Optional
+from typing import Union
 
 import pytest
 
@@ -188,3 +189,24 @@ def perform_regression_check(
             else:
                 dump_aux_fn(Path(obtained_filename))
                 raise
+
+
+def round_digits(data: Union[list, dict], prescision: int) -> Union[list, dict]:
+    """
+    Recusrsively Round the values of any float value in a collection to the given prescision.
+
+    :param data: The collection to round.
+    :param prescision: The number of decimal places to round to.
+    :return: The collection with all float values rounded to the given prescision.
+
+    """
+    # change the generator depending on the collection type
+    generator = enumerate(data) if isinstance(data, list) else data.items()
+    for k, v in generator:
+        if isinstance(v, (list, dict)):
+            data[k] = round_digits(v, prescision)
+        elif isinstance(v, float):
+            data[k] = round(v, prescision)
+        else:
+            data[k] = v
+    return data

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -193,6 +193,7 @@ def perform_regression_check(
 
 T = TypeVar("T", bound=Union[MutableSequence, MutableMapping])
 
+
 def round_digits(data: T, precision: int) -> T:
     """
     Recursively Round the values of any float value in a collection to the given precision.

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -201,13 +201,13 @@ def round_digits(data: T, digits: int) -> T:
     """
     Recursively round the values of any float value in a collection to the given number of digits. The rounding is done in-place.
 
-    :param data: 
+    :param data:
         The collection to round.
 
-    :param digits: 
+    :param digits:
         The number of digits to round to.
-    
-    :return: 
+
+    :return:
         The collection with all float values rounded to the given precision.
         Note that the rounding is done in-place, so this return value only exists
         because we use the function recursively.

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -191,7 +191,9 @@ def perform_regression_check(
                 raise
 
 
-def round_digits(data: Union[list, dict], prescision: int) -> Union[list, dict]:
+T = TypeVar("T", bound=Union[MutableSequence, MutableMapping])
+
+def round_digits(data: T, precision: int) -> T:
     """
     Recursively Round the values of any float value in a collection to the given precision.
 

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -193,7 +193,7 @@ def perform_regression_check(
 
 def round_digits(data: Union[list, dict], prescision: int) -> Union[list, dict]:
     """
-    Recusrsively Round the values of any float value in a collection to the given prescision.
+    Recursively Round the values of any float value in a collection to the given precision.
 
     :param data: The collection to round.
     :param prescision: The number of decimal places to round to.

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -3,7 +3,10 @@ import os
 from pathlib import Path
 from typing import Callable
 from typing import List
+from typing import MutableMapping
+from typing import MutableSequence
 from typing import Optional
+from typing import TypeVar
 from typing import Union
 
 import pytest
@@ -199,17 +202,17 @@ def round_digits(data: T, precision: int) -> T:
     Recursively Round the values of any float value in a collection to the given precision.
 
     :param data: The collection to round.
-    :param prescision: The number of decimal places to round to.
-    :return: The collection with all float values rounded to the given prescision.
+    :param precision: The number of decimal places to round to.
+    :return: The collection with all float values rounded to the given precision.
 
     """
     # change the generator depending on the collection type
     generator = enumerate(data) if isinstance(data, MutableSequence) else data.items()
     for k, v in generator:
         if isinstance(v, (MutableSequence, MutableMapping)):
-            data[k] = round_digits(v, prescision)
+            data[k] = round_digits(v, precision)
         elif isinstance(v, float):
-            data[k] = round(v, prescision)
+            data[k] = round(v, precision)
         else:
             data[k] = v
     return data

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -201,9 +201,9 @@ def round_digits(data: Union[list, dict], prescision: int) -> Union[list, dict]:
 
     """
     # change the generator depending on the collection type
-    generator = enumerate(data) if isinstance(data, list) else data.items()
+    generator = enumerate(data) if isinstance(data, MutableSequence) else data.items()
     for k, v in generator:
-        if isinstance(v, (list, dict)):
+        if isinstance(v, (MutableSequence, MutableMapping)):
             data[k] = round_digits(v, prescision)
         elif isinstance(v, float):
             data[k] = round(v, prescision)

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -59,7 +59,6 @@ class DataRegressionFixture:
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""
-            import yaml
 
             dumped_str = yaml.dump_all(
                 [data_dict],

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -11,6 +11,7 @@ import yaml
 
 from .common import check_text_files
 from .common import perform_regression_check
+from .common import round_digits_in_data
 
 
 class DataRegressionFixture:
@@ -55,7 +56,7 @@ class DataRegressionFixture:
         __tracebackhide__ = True
 
         if round_digits is not None:
-            round_digits(data_dict, round_digits)
+            round_digits_in_data(data_dict, round_digits)
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -33,7 +33,7 @@ class DataRegressionFixture:
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
         fullpath: Optional["os.PathLike[str]"] = None,
-        prescision: Optional[int] = None,
+        precision: Optional[int] = None,
     ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.
@@ -48,14 +48,14 @@ class DataRegressionFixture:
             will ignore ``datadir`` fixture when reading *expected* files but will still use it to
             write *obtained* files. Useful if a reference file is located in the session data dir for example.
 
-        :param prescision: if given, round all floats in the dict to the given number of digits.
+        :param precision: if given, round all floats in the dict to the given number of digits.
 
         ``basename`` and ``fullpath`` are exclusive.
         """
         __tracebackhide__ = True
 
-        if prescision is not None:
-            round_digits(data_dict, prescision)
+        if precision is not None:
+            round_digits(data_dict, precision)
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -33,7 +33,7 @@ class DataRegressionFixture:
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
         fullpath: Optional["os.PathLike[str]"] = None,
-        precision: Optional[int] = None,
+        round_digits: Optional[int] = None,
     ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.
@@ -48,14 +48,15 @@ class DataRegressionFixture:
             will ignore ``datadir`` fixture when reading *expected* files but will still use it to
             write *obtained* files. Useful if a reference file is located in the session data dir for example.
 
-        :param precision: if given, round all floats in the dict to the given number of digits.
+        :param round_digits: 
+            If given, round all floats in the dict to the given number of digits.
 
         ``basename`` and ``fullpath`` are exclusive.
         """
         __tracebackhide__ = True
 
-        if precision is not None:
-            round_digits(data_dict, precision)
+        if round_digits is not None:
+            round_digits(data_dict, round_digits)
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -11,6 +11,7 @@ import yaml
 
 from .common import check_text_files
 from .common import perform_regression_check
+from .common import round_digits
 
 
 class DataRegressionFixture:
@@ -32,6 +33,7 @@ class DataRegressionFixture:
         data_dict: Dict[str, Any],
         basename: Optional[str] = None,
         fullpath: Optional["os.PathLike[str]"] = None,
+        prescision: Optional[int] = None,
     ) -> None:
         """
         Checks the given dict against a previously recorded version, or generate a new file.
@@ -46,9 +48,14 @@ class DataRegressionFixture:
             will ignore ``datadir`` fixture when reading *expected* files but will still use it to
             write *obtained* files. Useful if a reference file is located in the session data dir for example.
 
+        :param prescision: if given, round all floats in the dict to the given number of digits.
+
         ``basename`` and ``fullpath`` are exclusive.
         """
         __tracebackhide__ = True
+
+        if prescision is not None:
+            data_dict = round_digits(data_dict, prescision)
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -55,7 +55,7 @@ class DataRegressionFixture:
         __tracebackhide__ = True
 
         if prescision is not None:
-            data_dict = round_digits(data_dict, prescision)
+            round_digits(data_dict, prescision)
 
         def dump(filename: Path) -> None:
             """Dump dict contents to the given filename"""

--- a/src/pytest_regressions/data_regression.py
+++ b/src/pytest_regressions/data_regression.py
@@ -11,7 +11,6 @@ import yaml
 
 from .common import check_text_files
 from .common import perform_regression_check
-from .common import round_digits
 
 
 class DataRegressionFixture:
@@ -48,7 +47,7 @@ class DataRegressionFixture:
             will ignore ``datadir`` fixture when reading *expected* files but will still use it to
             write *obtained* files. Useful if a reference file is located in the session data dir for example.
 
-        :param round_digits: 
+        :param round_digits:
             If given, round all floats in the dict to the given number of digits.
 
         ``basename`` and ``fullpath`` are exclusive.

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -38,6 +38,15 @@ def test_custom_object(data_regression):
     data_regression.check(contents)
 
 
+def test_round_digits(data_regression):
+    """Example including float numbers and check rounding capabilities."""
+    contents = {
+        "content": {"value1": "toto", "value": 1.123456789},
+        "value": 1.23456789,
+    }
+    data_regression.check(contents, prescision=2)
+
+
 def test_usage_workflow(pytester, monkeypatch):
     monkeypatch.setattr(
         sys, "testing_get_data", lambda: {"contents": "Foo", "value": 10}, raising=False

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -46,7 +46,7 @@ def test_round_digits(data_regression):
         "value": 1.23456789,
     }
     data_regression.check(contents, precision=2)
-    
+
     with pytest.raises(AssertionError):
         contents = {
             "content": {"value1": "toto", "value": 1.2345678},

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -1,6 +1,7 @@
 import sys
 from textwrap import dedent
 
+import pytest
 import yaml
 
 from pytest_regressions.testing import check_regression_fixture_workflow

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -42,9 +42,18 @@ def test_round_digits(data_regression):
     """Example including float numbers and check rounding capabilities."""
     contents = {
         "content": {"value1": "toto", "value": 1.123456789},
+        "values": [1.12345, 2.34567],
         "value": 1.23456789,
     }
-    data_regression.check(contents, prescision=2)
+    data_regression.check(contents, precision=2)
+    
+    with pytest.raises(AssertionError):
+        contents = {
+            "content": {"value1": "toto", "value": 1.2345678},
+            "values": [1.13456, 2.45678],
+            "value": 1.23456789,
+        }
+        data_regression.check(contents, precision=2)
 
 
 def test_usage_workflow(pytester, monkeypatch):

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -46,7 +46,7 @@ def test_round_digits(data_regression):
         "values": [1.12345, 2.34567],
         "value": 1.23456789,
     }
-    data_regression.check(contents, precision=2)
+    data_regression.check(contents, round_digits=2)
 
     with pytest.raises(AssertionError):
         contents = {
@@ -54,7 +54,7 @@ def test_round_digits(data_regression):
             "values": [1.13456, 2.45678],
             "value": 1.23456789,
         }
-        data_regression.check(contents, precision=2)
+        data_regression.check(contents, round_digits=2)
 
 
 def test_usage_workflow(pytester, monkeypatch):

--- a/tests/test_data_regression/test_round_digits.yml
+++ b/tests/test_data_regression/test_round_digits.yml
@@ -1,0 +1,4 @@
+content:
+  value: 1.12
+  value1: toto
+value: 1.23

--- a/tests/test_data_regression/test_round_digits.yml
+++ b/tests/test_data_regression/test_round_digits.yml
@@ -2,3 +2,6 @@ content:
   value: 1.12
   value1: toto
 value: 1.23
+values:
+- 1.12
+- 2.35


### PR DESCRIPTION
Fix #170 
Fix #159 

This PR add a `prescision` parameter to the data_regression check. If unset the behaviour remain unchanged, if setn then any float value in the data_dict will be rounded to the specified number of digits. It will allow to handle more complex data shapes directly in the data_regression fixture and keep them in a humanly readable file format: yaml. 