### PR TITLE
fix: add fullpath option to ImageRegression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 
 * Python 3.12 and 3.13 are now officially supported.
 * Python 3.8 (EOL) is no longer supported.
+* `#184 <https://github.com/ESSS/pytest-regressions/pull/184>`__: Added ``fullpath`` parameter to ``image_regression.check``.
 
 
 2.6.0

--- a/src/pytest_regressions/image_regression.py
+++ b/src/pytest_regressions/image_regression.py
@@ -137,6 +137,7 @@ class ImageRegressionFixture:
         diff_threshold: float = 0.1,
         expect_equal: bool = True,
         basename: Optional[str] = None,
+        fullpath: Optional["os.PathLike[str]"] = None,
     ) -> None:
         """
         Checks that the given image contents are comparable with the ones stored in the data directory.
@@ -148,6 +149,11 @@ class ImageRegressionFixture:
             image should be considered different at least above the threshold.
         :param diff_threshold:
             Tolerance as a percentage (1 to 100) on how the images are allowed to differ.
+        :param fullpath: complete path to use as a reference file. This option
+            will ignore ``datadir`` fixture when reading *expected* files but will still use it to
+            write *obtained* files. Useful if a reference file is located in the session data dir for example.
+
+        ``basename`` and ``fullpath`` are exclusive.
         """
         __tracebackhide__ = True
 
@@ -172,6 +178,7 @@ class ImageRegressionFixture:
             dump_fn=dump_fn,
             extension=".png",
             basename=basename,
+            fullpath=fullpath,
             force_regen=self.force_regen,
             with_test_class_names=self.with_test_class_names,
         )


### PR DESCRIPTION
Fix #183
I guess ther fullpath option have bee created after the ImageRegression. From my understanding of the package this is the only needed change to make it work as `perform_regression_check` is doing all the heavy lifting. 