### PR TITLE
refactor: update the dataframe checks to drop deprecated "a" type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+UNRELEASED
+----------
+
+*UNRELEASED*
+
+* `#173 <https://github.com/ESSS/pytest-regressions/issues/173>`__: Removed check against numpy-2.0-deprecated ``a`` dtype alias.
+
 2.8.0
 -----
 

--- a/src/pytest_regressions/dataframe_regression.py
+++ b/src/pytest_regressions/dataframe_regression.py
@@ -253,7 +253,7 @@ class DataFrameRegressionFixture:
             if (array.dtype == "O") and (type(array.iloc[0]) is str):
                 continue
             # Rejected: timedelta, datetime, objects, zero-terminated bytes, unicode strings and raw data
-            assert array.dtype not in ["m", "M", "O", "S", "a", "U", "V"], (
+            assert array.dtype.kind not in ["m", "M", "O", "S", "U", "V"], (
                 "Only numeric data is supported on dataframe_regression fixture.\n"
                 "Array with type '%s' was given." % (str(array.dtype),)
             )


### PR DESCRIPTION
Fix #173 

The "a" allias is now deprecated so I dropped it from the list of checks we perform in the asset. 
To be slightly more future proof I change the check into `array.dtype.kind`. `kind` is the `dtype` attribute that will always return the general kind of the data no matter the allias (or exotic type) you are using e.g.: 

```python 
>>> dt = np.dtype('i4')
>>> dt.kind
'i'
```

more info on numpy documentation: https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html

  