### PR TITLE
Ignore ResourceWarning about unclosed file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
 [pytest]
 filterwarnings=
     error
+    ignore:unclosed file:ResourceWarning
     ignore:Pyarrow will become a required dependency of pandas:DeprecationWarning
     ignore:can't resolve package from __spec__:ImportWarning
     ignore:The pandas.json module is deprecated:FutureWarning


### PR DESCRIPTION
This is happening on Windows about pytest.exe. Ignoring for now.