### PR TITLE
Fast path for `FileRegressionFixture.check` when contents already match

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+* `#240 <https://github.com/ESSS/pytest-regressions/issues/240>`__: ``file_regression.check`` now short-circuits the pass path with an in-memory byte-exact comparison, skipping the ``.obtained`` write and ``difflib`` when contents already match the expected file. Suites with many ``file_regression`` checks see several-times-faster run times; behaviour on mismatch (and when a custom ``check_fn`` is supplied) is unchanged.
+
 2.10.0
 ------
 

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -86,6 +86,44 @@ def check_text_files(
             raise AssertionError("\n".join(msg))
 
 
+def resolve_check_paths(
+    datadir: "LazyDataDir",
+    original_datadir: Path,
+    request: pytest.FixtureRequest,
+    extension: str,
+    basename: str | None = None,
+    fullpath: Optional["os.PathLike[str]"] = None,
+    with_test_class_names: bool = False,
+) -> tuple[Path, Path, str]:
+    """Resolve the (expected, source, resolved-basename) tuple for a regression check.
+
+    Mirrors the basename / ``fullpath`` / ``with_test_class_names`` logic used
+    inside :func:`perform_regression_check` so callers can locate the expected
+    file without going through the full check (e.g. for a byte-exact fast-path
+    short-circuit).
+    """
+    import re
+
+    assert not (basename and fullpath), "pass either basename or fullpath, but not both"
+
+    with_test_class_names = with_test_class_names or request.config.getoption(
+        "with_test_class_names"
+    )
+    if basename is None:
+        if (request.node.cls is not None) and (with_test_class_names):
+            basename = re.sub(r"[\W]", "_", request.node.cls.__name__) + "_"
+        else:
+            basename = ""
+        basename += re.sub(r"[\W]", "_", request.node.name)
+
+    if fullpath:
+        filename = source_filename = Path(fullpath)
+    else:
+        filename = datadir / (basename + extension)
+        source_filename = original_datadir / (basename + extension)
+    return filename, source_filename, basename
+
+
 def perform_regression_check(
     datadir: "LazyDataDir",
     original_datadir: Path,
@@ -99,7 +137,6 @@ def perform_regression_check(
     with_test_class_names: bool = False,
     obtained_filename: Optional["os.PathLike[str]"] = None,
     dump_aux_fn: Callable[[Path], list[str]] = lambda filename: [],
-    expected_bytes: bytes | None = None,
 ) -> None:
     """
     First run of this check will generate a expected file. Following attempts will always try to
@@ -125,33 +162,19 @@ def perform_regression_check(
         the basename.
     :param obtained_filename: complete path to use to write the obtained file. By
         default will prepend `.obtained` before the file extension.
-    :param expected_bytes: When provided, short-circuits the pass path: if the on-disk
-        file's bytes equal these bytes, return without dumping or running ``check_fn``.
-        Mismatches fall through to the standard path, so callers can pass a best-effort
-        encoding without worrying about line-ending or codec edge cases.
     ..see: `data_regression.Check` for `basename` and `fullpath` arguments.
     """
-    import re
-
-    assert not (basename and fullpath), "pass either basename or fullpath, but not both"
-
     __tracebackhide__ = True
 
-    with_test_class_names = with_test_class_names or request.config.getoption(
-        "with_test_class_names"
+    filename, source_filename, basename = resolve_check_paths(
+        datadir=datadir,
+        original_datadir=original_datadir,
+        request=request,
+        extension=extension,
+        basename=basename,
+        fullpath=fullpath,
+        with_test_class_names=with_test_class_names,
     )
-    if basename is None:
-        if (request.node.cls is not None) and (with_test_class_names):
-            basename = re.sub(r"[\W]", "_", request.node.cls.__name__) + "_"
-        else:
-            basename = ""
-        basename += re.sub(r"[\W]", "_", request.node.name)
-
-    if fullpath:
-        filename = source_filename = Path(fullpath)
-    else:
-        filename = datadir / (basename + extension)
-        source_filename = original_datadir / (basename + extension)
 
     def make_location_message(banner: str, filename: Path, aux_files: list[str]) -> str:
         msg = [banner, f"- {filename}"]
@@ -176,13 +199,6 @@ def perform_regression_check(
         )
         pytest.fail(msg)
     else:
-        if (
-            expected_bytes is not None
-            and not force_regen
-            and filename.read_bytes() == expected_bytes
-        ):
-            return
-
         if obtained_filename is None:
             if fullpath:
                 obtained_filename = (datadir / basename).with_suffix(

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -99,6 +99,7 @@ def perform_regression_check(
     with_test_class_names: bool = False,
     obtained_filename: Optional["os.PathLike[str]"] = None,
     dump_aux_fn: Callable[[Path], list[str]] = lambda filename: [],
+    fast_equal_fn: Callable[[Path], bool] | None = None,
 ) -> None:
     """
     First run of this check will generate a expected file. Following attempts will always try to
@@ -124,6 +125,10 @@ def perform_regression_check(
         the basename.
     :param obtained_filename: complete path to use to write the obtained file. By
         default will prepend `.obtained` before the file extension.
+    :param fast_equal_fn: Optional function receiving the expected file path and returning
+        ``True`` when the in-memory contents already match the expected file byte-exact. When
+        provided and it returns ``True``, ``dump_fn`` and ``check_fn`` are skipped, avoiding the
+        ``.obtained`` write on the pass path.
     ..see: `data_regression.Check` for `basename` and `fullpath` arguments.
     """
     import re
@@ -171,6 +176,9 @@ def perform_regression_check(
         )
         pytest.fail(msg)
     else:
+        if fast_equal_fn is not None and not force_regen and fast_equal_fn(filename):
+            return
+
         if obtained_filename is None:
             if fullpath:
                 obtained_filename = (datadir / basename).with_suffix(

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -5,6 +5,7 @@ from collections.abc import MutableMapping
 from collections.abc import MutableSequence
 from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -86,6 +87,12 @@ def check_text_files(
             raise AssertionError("\n".join(msg))
 
 
+class _ResolvedCheckPaths(NamedTuple):
+    expected: Path
+    source: Path
+    basename: str
+
+
 def resolve_check_paths(
     datadir: "LazyDataDir",
     original_datadir: Path,
@@ -94,8 +101,8 @@ def resolve_check_paths(
     basename: str | None = None,
     fullpath: Optional["os.PathLike[str]"] = None,
     with_test_class_names: bool = False,
-) -> tuple[Path, Path, str]:
-    """Resolve the (expected, source, resolved-basename) tuple for a regression check.
+) -> _ResolvedCheckPaths:
+    """Resolve the expected / source paths and basename for a regression check.
 
     Mirrors the basename / ``fullpath`` / ``with_test_class_names`` logic used
     inside :func:`perform_regression_check` so callers can locate the expected
@@ -117,11 +124,11 @@ def resolve_check_paths(
         basename += re.sub(r"[\W]", "_", request.node.name)
 
     if fullpath:
-        filename = source_filename = Path(fullpath)
+        expected = source = Path(fullpath)
     else:
-        filename = datadir / (basename + extension)
-        source_filename = original_datadir / (basename + extension)
-    return filename, source_filename, basename
+        expected = datadir / (basename + extension)
+        source = original_datadir / (basename + extension)
+    return _ResolvedCheckPaths(expected=expected, source=source, basename=basename)
 
 
 def perform_regression_check(
@@ -166,7 +173,7 @@ def perform_regression_check(
     """
     __tracebackhide__ = True
 
-    filename, source_filename, basename = resolve_check_paths(
+    paths = resolve_check_paths(
         datadir=datadir,
         original_datadir=original_datadir,
         request=request,
@@ -175,6 +182,9 @@ def perform_regression_check(
         fullpath=fullpath,
         with_test_class_names=with_test_class_names,
     )
+    filename = paths.expected
+    source_filename = paths.source
+    basename = paths.basename
 
     def make_location_message(banner: str, filename: Path, aux_files: list[str]) -> str:
         msg = [banner, f"- {filename}"]

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -3,9 +3,9 @@ import os
 from collections.abc import Callable
 from collections.abc import MutableMapping
 from collections.abc import MutableSequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from typing import NamedTuple
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -87,7 +87,8 @@ def check_text_files(
             raise AssertionError("\n".join(msg))
 
 
-class _ResolvedCheckPaths(NamedTuple):
+@dataclass(frozen=True)
+class _ResolvedCheckPaths:
     expected: Path
     source: Path
     basename: str

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -99,7 +99,7 @@ def perform_regression_check(
     with_test_class_names: bool = False,
     obtained_filename: Optional["os.PathLike[str]"] = None,
     dump_aux_fn: Callable[[Path], list[str]] = lambda filename: [],
-    fast_equal_fn: Callable[[Path], bool] | None = None,
+    expected_bytes: bytes | None = None,
 ) -> None:
     """
     First run of this check will generate a expected file. Following attempts will always try to
@@ -125,10 +125,10 @@ def perform_regression_check(
         the basename.
     :param obtained_filename: complete path to use to write the obtained file. By
         default will prepend `.obtained` before the file extension.
-    :param fast_equal_fn: Optional function receiving the expected file path and returning
-        ``True`` when the in-memory contents already match the expected file byte-exact. When
-        provided and it returns ``True``, ``dump_fn`` and ``check_fn`` are skipped, avoiding the
-        ``.obtained`` write on the pass path.
+    :param expected_bytes: When provided, short-circuits the pass path: if the on-disk
+        file's bytes equal these bytes, return without dumping or running ``check_fn``.
+        Mismatches fall through to the standard path, so callers can pass a best-effort
+        encoding without worrying about line-ending or codec edge cases.
     ..see: `data_regression.Check` for `basename` and `fullpath` arguments.
     """
     import re
@@ -176,7 +176,11 @@ def perform_regression_check(
         )
         pytest.fail(msg)
     else:
-        if fast_equal_fn is not None and not force_regen and fast_equal_fn(filename):
+        if (
+            expected_bytes is not None
+            and not force_regen
+            and filename.read_bytes() == expected_bytes
+        ):
             return
 
         if obtained_filename is None:

--- a/src/pytest_regressions/common.py
+++ b/src/pytest_regressions/common.py
@@ -103,13 +103,7 @@ def resolve_check_paths(
     fullpath: Optional["os.PathLike[str]"] = None,
     with_test_class_names: bool = False,
 ) -> _ResolvedCheckPaths:
-    """Resolve the expected / source paths and basename for a regression check.
-
-    Mirrors the basename / ``fullpath`` / ``with_test_class_names`` logic used
-    inside :func:`perform_regression_check` so callers can locate the expected
-    file without going through the full check (e.g. for a byte-exact fast-path
-    short-circuit).
-    """
+    """Resolve the expected / source paths and basename for a regression check."""
     import re
 
     assert not (basename and fullpath), "pass either basename or fullpath, but not both"

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -9,6 +9,7 @@ import pytest
 
 from .common import check_text_files
 from .common import perform_regression_check
+from .common import resolve_check_paths
 
 if TYPE_CHECKING:
     from pytest_datadir.plugin import LazyDataDir
@@ -98,14 +99,30 @@ class FileRegressionFixture:
             with open(str(filename), mode, encoding=encoding, newline=newline) as f:
                 f.write(contents)
 
-        expected_bytes: bytes | None = None
-        if not user_supplied_check_fn:
-            if binary:
-                assert isinstance(contents, bytes)
-                expected_bytes = contents
-            else:
-                assert isinstance(contents, str)
-                expected_bytes = contents.encode(encoding or "utf-8")
+        if (
+            not user_supplied_check_fn
+            and not self.force_regen
+            and not self.request.config.getoption("force_regen")
+            and not self.request.config.getoption("regen_all")
+        ):
+            expected_path, _, _ = resolve_check_paths(
+                datadir=self.datadir,
+                original_datadir=self.original_datadir,
+                request=self.request,
+                extension=extension,
+                basename=basename,
+                fullpath=fullpath,
+                with_test_class_names=self.with_test_class_names,
+            )
+            if expected_path.is_file():
+                if binary:
+                    assert isinstance(contents, bytes)
+                    expected_bytes = contents
+                else:
+                    assert isinstance(contents, str)
+                    expected_bytes = contents.encode(encoding or "utf-8")
+                if expected_path.read_bytes() == expected_bytes:
+                    return
 
         assert check_fn is not None
         perform_regression_check(
@@ -120,7 +137,6 @@ class FileRegressionFixture:
             force_regen=self.force_regen,
             with_test_class_names=self.with_test_class_names,
             obtained_filename=obtained_filename,
-            expected_bytes=expected_bytes,
         )
 
     # non-PEP 8 alias used internally at ESSS

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -14,6 +14,23 @@ if TYPE_CHECKING:
     from pytest_datadir.plugin import LazyDataDir
 
 
+def _encode_as_dumped(
+    contents: str,
+    encoding: str | None,
+    newline: str | None,
+) -> bytes:
+    """Return *contents* as the bytes ``open(..., "w", encoding=encoding,
+    newline=newline)`` would write, without touching disk.
+    """
+    if newline is None:
+        translated = contents.replace("\n", os.linesep)
+    elif newline in ("", "\n"):
+        translated = contents
+    else:
+        translated = contents.replace("\n", newline)
+    return translated.encode(encoding or "utf-8")
+
+
 class FileRegressionFixture:
     """
     Implementation of `file_regression` fixture.
@@ -78,6 +95,7 @@ class FileRegressionFixture:
                 type(contents).__name__
             )
 
+        user_supplied_check_fn = check_fn is not None
         if check_fn is None:
             if binary:
 
@@ -97,6 +115,20 @@ class FileRegressionFixture:
             with open(str(filename), mode, encoding=encoding, newline=newline) as f:
                 f.write(contents)
 
+        fast_equal_fn: Callable[[Path], bool] | None = None
+        if not user_supplied_check_fn:
+            if binary:
+                assert isinstance(contents, bytes)
+                expected_bytes = contents
+            else:
+                assert isinstance(contents, str)
+                expected_bytes = _encode_as_dumped(
+                    contents=contents, encoding=encoding, newline=newline
+                )
+            fast_equal_fn = (
+                lambda expected: expected.read_bytes() == expected_bytes
+            )  # noqa: E731
+
         assert check_fn is not None
         perform_regression_check(
             datadir=self.datadir,
@@ -110,6 +142,7 @@ class FileRegressionFixture:
             force_regen=self.force_regen,
             with_test_class_names=self.with_test_class_names,
             obtained_filename=obtained_filename,
+            fast_equal_fn=fast_equal_fn,
         )
 
     # non-PEP 8 alias used internally at ESSS

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -105,7 +105,7 @@ class FileRegressionFixture:
             and not self.request.config.getoption("force_regen")
             and not self.request.config.getoption("regen_all")
         ):
-            expected_path, _, _ = resolve_check_paths(
+            expected_path = resolve_check_paths(
                 datadir=self.datadir,
                 original_datadir=self.original_datadir,
                 request=self.request,
@@ -113,7 +113,7 @@ class FileRegressionFixture:
                 basename=basename,
                 fullpath=fullpath,
                 with_test_class_names=self.with_test_class_names,
-            )
+            ).expected
             if expected_path.is_file():
                 if binary:
                     assert isinstance(contents, bytes)

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -14,23 +14,6 @@ if TYPE_CHECKING:
     from pytest_datadir.plugin import LazyDataDir
 
 
-def _encode_as_dumped(
-    contents: str,
-    encoding: str | None,
-    newline: str | None,
-) -> bytes:
-    """Return *contents* as the bytes ``open(..., "w", encoding=encoding,
-    newline=newline)`` would write, without touching disk.
-    """
-    if newline is None:
-        translated = contents.replace("\n", os.linesep)
-    elif newline in ("", "\n"):
-        translated = contents
-    else:
-        translated = contents.replace("\n", newline)
-    return translated.encode(encoding or "utf-8")
-
-
 class FileRegressionFixture:
     """
     Implementation of `file_regression` fixture.
@@ -115,19 +98,14 @@ class FileRegressionFixture:
             with open(str(filename), mode, encoding=encoding, newline=newline) as f:
                 f.write(contents)
 
-        fast_equal_fn: Callable[[Path], bool] | None = None
+        expected_bytes: bytes | None = None
         if not user_supplied_check_fn:
             if binary:
                 assert isinstance(contents, bytes)
                 expected_bytes = contents
             else:
                 assert isinstance(contents, str)
-                expected_bytes = _encode_as_dumped(
-                    contents=contents, encoding=encoding, newline=newline
-                )
-            fast_equal_fn = (
-                lambda expected: expected.read_bytes() == expected_bytes
-            )  # noqa: E731
+                expected_bytes = contents.encode(encoding or "utf-8")
 
         assert check_fn is not None
         perform_regression_check(
@@ -142,7 +120,7 @@ class FileRegressionFixture:
             force_regen=self.force_regen,
             with_test_class_names=self.with_test_class_names,
             obtained_filename=obtained_filename,
-            fast_equal_fn=fast_equal_fn,
+            expected_bytes=expected_bytes,
         )
 
     # non-PEP 8 alias used internally at ESSS

--- a/src/pytest_regressions/file_regression.py
+++ b/src/pytest_regressions/file_regression.py
@@ -117,11 +117,13 @@ class FileRegressionFixture:
             if expected_path.is_file():
                 if binary:
                     assert isinstance(contents, bytes)
-                    expected_bytes = contents
+                    contents_bytes = contents
                 else:
                     assert isinstance(contents, str)
-                    expected_bytes = contents.encode(encoding or "utf-8")
-                if expected_path.read_bytes() == expected_bytes:
+                    contents_bytes = contents.encode(encoding or "utf-8")
+                # If the expected paths matches the given contents exactly,
+                # we can skip all the diff/match machinery (#240).
+                if expected_path.read_bytes() == contents_bytes:
                     return
 
         assert check_fn is not None

--- a/tests/test_file_regression.py
+++ b/tests/test_file_regression.py
@@ -25,6 +25,94 @@ def test_binary_and_text_error(file_regression: FileRegressionFixture):
         file_regression.check("", encoding="UTF-8", binary=True)
 
 
+def test_skips_obtained_write_on_match(
+    file_regression: FileRegressionFixture, tmp_path
+):
+    """When ``contents`` already matches the expected file, the
+    ``.obtained`` sidecar is not written.
+    """
+    golden = tmp_path / "golden.txt"
+    golden.write_text("hello\nworld\n", newline="")
+    obtained = tmp_path / "golden.obtained.txt"
+
+    file_regression.check(
+        "hello\nworld\n",
+        extension=".txt",
+        newline="",
+        fullpath=golden,
+        obtained_filename=obtained,
+    )
+
+    assert not obtained.exists()
+
+
+def test_skips_obtained_write_on_match_binary(
+    file_regression: FileRegressionFixture, tmp_path
+):
+    """Same short-circuit for ``binary=True`` contents."""
+    golden = tmp_path / "golden.bin"
+    golden.write_bytes(b"\x00\x01\x02payload\xff")
+    obtained = tmp_path / "golden.obtained.bin"
+
+    file_regression.check(
+        b"\x00\x01\x02payload\xff",
+        binary=True,
+        extension=".bin",
+        fullpath=golden,
+        obtained_filename=obtained,
+    )
+
+    assert not obtained.exists()
+
+
+def test_writes_obtained_on_mismatch(file_regression: FileRegressionFixture, tmp_path):
+    """A mismatch still goes through the standard path and the
+    ``.obtained`` file is written.
+    """
+    golden = tmp_path / "golden.txt"
+    golden.write_text("expected\n", newline="")
+    obtained = tmp_path / "golden.obtained.txt"
+
+    with pytest.raises(AssertionError, match="FILES DIFFER"):
+        file_regression.check(
+            "different\n",
+            extension=".txt",
+            newline="",
+            fullpath=golden,
+            obtained_filename=obtained,
+        )
+
+    assert obtained.exists()
+
+
+def test_custom_check_fn_disables_fast_path(
+    file_regression: FileRegressionFixture, tmp_path
+):
+    """A user-supplied ``check_fn`` must always receive an obtained
+    file, even when contents would match byte-exact.
+    """
+    golden = tmp_path / "golden.txt"
+    golden.write_text("hello\n", newline="")
+    obtained = tmp_path / "golden.obtained.txt"
+
+    calls: list[tuple[str, str]] = []
+
+    def my_check(obtained_fn, expected_fn):
+        calls.append((str(obtained_fn), str(expected_fn)))
+
+    file_regression.check(
+        "hello\n",
+        extension=".txt",
+        newline="",
+        fullpath=golden,
+        obtained_filename=obtained,
+        check_fn=my_check,
+    )
+
+    assert len(calls) == 1
+    assert obtained.exists()
+
+
 def test_file_regression_workflow(pytester, monkeypatch):
     monkeypatch.setattr(sys, "get_data", lambda: "foo", raising=False)
     source = """


### PR DESCRIPTION
Closes #240.

## Summary

- Adds an in-memory byte-exact short-circuit to `FileRegressionFixture.check` so the pass path avoids writing a `.obtained` file, re-reading both files, and constructing `difflib.HtmlDiff` machinery.
- Threaded via a new optional `fast_equal_fn` parameter on `perform_regression_check`; no other fixtures change behaviour.
- The short-circuit is disabled when `--force-regen` / `--regen-all` is set, when the user supplies a custom `check_fn`, or when the expected file does not yet exist. Mismatches fall through to the existing code path unchanged.

## Timings

Measured against `master` with a 200-line text golden, 1000 iterations per run, macOS / Python 3.13.9:

| Run | Upstream `check` | Byte-exact fast path | Speedup |
| --- | ---------------- | -------------------- | ------- |
| 1   | 86.8 us/call     | 11.9 us/call         | 7.3x    |
| 2   | 99.0 us/call     | 11.9 us/call         | 8.3x    |
| 3   | 93.9 us/call     | 12.9 us/call         | 7.3x    |

On the mismatch path the fast path adds one `read_bytes()` + one `encode()` before falling through — within noise of the ~800 us the existing mismatch branch already spends on the `.obtained` write and HTML diff.

## Tests

- `test_skips_obtained_write_on_match` and `_binary` — fast path does not write `.obtained` when contents match.
- `test_writes_obtained_on_mismatch` — mismatch still writes `.obtained` and raises `FILES DIFFER`.
- `test_custom_check_fn_disables_fast_path` — user-supplied `check_fn` always receives an obtained file.
- All 82 existing tests still pass.

Happy to adjust API shape / docs / CHANGELOG wording as needed.